### PR TITLE
Add a summary document for the dataframe interchange protocol

### DIFF
--- a/protocol/dataframe_protocol_summary.md
+++ b/protocol/dataframe_protocol_summary.md
@@ -113,9 +113,12 @@ this is a consequence, and that that should be acceptable to them.
 We'll also list some things that were discussed but are not requirements:
 
 1. Object dtype does not need to be supported
-2. Heterogeneous/structured dtypes within a single column does not need to be
+2. Nested/structured dtypes within a single column does not need to be
    supported.
-   _Rationale: not used a lot, additional design complexity not justified._
+   _Rationale: not used a lot, additional design complexity not justified.
+   May be added in the future (does have support in the Arrow C Data Interface)._
+3. Extension dtypes do not need to be supported.
+   _Rationale: same as (2)_
 
 
 ## Frequently asked questions


### PR DESCRIPTION
Summarizes the various discussions about and goals/non-goals and requirements for the `__dataframe__` data interchange protocol.

The intended audience for this document is Consortium members and dataframe library maintainers who may want to support this protocol. @datapythonista will add a companion document that's a more gentle introduction/tutorial in a "from zero to a protocol" style.

The aim is to keep updating this till we have captured all the requirements and answered all the FAQs, so we can actually design the protocol after and verify it meets all our requirements.

Closes gh-29, xref gh-25.