### PR TITLE
Add comparison methods

### DIFF
--- a/spec/API_specification/comparison_methods.md
+++ b/spec/API_specification/comparison_methods.md
@@ -12,7 +12,7 @@ A conforming implementation of the dataframe API standard must provide and suppo
 <!-- NOTE: please keep the methods in alphabetical order -->
 
 (method-eq)=
-### eq(other, /, *, axis=None)
+### eq(other)
 
 Computes the truth value of `df_i == other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
 
@@ -22,10 +22,6 @@ Computes the truth value of `df_i == other_i` for each element `df_i` of the dat
 
     -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
 
--   **axis**: _Optional\[ int ]_
-
-    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
-
 #### Returns
 
 -   **out**: _&lt;dataframe&gt;_
@@ -33,7 +29,7 @@ Computes the truth value of `df_i == other_i` for each element `df_i` of the dat
     -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
 
 (method-ge)=
-### ge(other, /, *, axis=None)
+### ge(other, /)
 
 Computes the truth value of `df_i >= other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
 
@@ -43,10 +39,6 @@ Computes the truth value of `df_i >= other_i` for each element `df_i` of the dat
 
     -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
 
--   **axis**: _Optional\[ int ]_
-
-    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
-
 #### Returns
 
 -   **out**: _&lt;dataframe&gt;_
@@ -54,7 +46,7 @@ Computes the truth value of `df_i >= other_i` for each element `df_i` of the dat
     -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
 
 (method-gt)=
-### gt(other, /, *, axis=None)
+### gt(other, /)
 
 Computes the truth value of `df_i > other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
 
@@ -64,10 +56,6 @@ Computes the truth value of `df_i > other_i` for each element `df_i` of the data
 
     -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
 
--   **axis**: _Optional\[ int ]_
-
-    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
-
 #### Returns
 
 -   **out**: _&lt;dataframe&gt;_
@@ -75,7 +63,7 @@ Computes the truth value of `df_i > other_i` for each element `df_i` of the data
     -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
 
 (method-le)=
-### le(other, /, *, axis=None)
+### le(other, /)
 
 Computes the truth value of `df_i <= other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
 
@@ -85,10 +73,6 @@ Computes the truth value of `df_i <= other_i` for each element `df_i` of the dat
 
     -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
 
--   **axis**: _Optional\[ int ]_
-
-    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
-
 #### Returns
 
 -   **out**: _&lt;dataframe&gt;_
@@ -96,7 +80,7 @@ Computes the truth value of `df_i <= other_i` for each element `df_i` of the dat
     -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
 
 (method-lt)=
-### lt(other, /, *, axis=None)
+### lt(other, /)
 
 Computes the truth value of `df_i < other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
 
@@ -106,10 +90,6 @@ Computes the truth value of `df_i < other_i` for each element `df_i` of the data
 
     -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
 
--   **axis**: _Optional\[ int ]_
-
-    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
-
 #### Returns
 
 -   **out**: _&lt;dataframe&gt;_
@@ -117,7 +97,7 @@ Computes the truth value of `df_i < other_i` for each element `df_i` of the data
     -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
 
 (method-ne)=
-### ne(other, /, *, axis=None)
+### ne(other, /)
 
 Computes the truth value of `df_i != other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
 
@@ -126,10 +106,6 @@ Computes the truth value of `df_i != other_i` for each element `df_i` of the dat
 -   **other**: _&lt;dataframe&gt;_
 
     -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
-
--   **axis**: _Optional\[ int ]_
-
-    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
 
 #### Returns
 

--- a/spec/API_specification/comparison_methods.md
+++ b/spec/API_specification/comparison_methods.md
@@ -1,0 +1,138 @@
+# Comparison Methods
+
+> Dataframe API specification for comparison methods.
+
+A conforming implementation of the dataframe API standard must provide and support the following methods adhering to the following conventions.
+
+-   Positional parameters must be [positional-only](https://www.python.org/dev/peps/pep-0570/) parameters. Positional-only parameters have no externally-usable name. When a method accepting positional-only parameters is called, positional arguments are mapped to these parameters based solely on their order.
+-   Optional parameters must be [keyword-only](https://www.python.org/dev/peps/pep-3102/) arguments.
+
+## Methods
+
+<!-- NOTE: please keep the methods in alphabetical order -->
+
+(method-eq)=
+### eq(other, /, *, axis=None)
+
+Computes the truth value of `df_i == other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
+
+#### Parameters
+
+-   **other**: _&lt;dataframe&gt;_
+
+    -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;dataframe&gt;_
+
+    -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
+
+(method-ge)=
+### ge(other, /, *, axis=None)
+
+Computes the truth value of `df_i >= other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
+
+#### Parameters
+
+-   **other**: _&lt;dataframe&gt;_
+
+    -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;dataframe&gt;_
+
+    -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
+
+(method-gt)=
+### gt(other, /, *, axis=None)
+
+Computes the truth value of `df_i > other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
+
+#### Parameters
+
+-   **other**: _&lt;dataframe&gt;_
+
+    -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;dataframe&gt;_
+
+    -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
+
+(method-le)=
+### le(other, /, *, axis=None)
+
+Computes the truth value of `df_i <= other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
+
+#### Parameters
+
+-   **other**: _&lt;dataframe&gt;_
+
+    -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;dataframe&gt;_
+
+    -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
+
+(method-lt)=
+### lt(other, /, *, axis=None)
+
+Computes the truth value of `df_i < other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
+
+#### Parameters
+
+-   **other**: _&lt;dataframe&gt;_
+
+    -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;dataframe&gt;_
+
+    -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.
+
+(method-ne)=
+### ne(other, /, *, axis=None)
+
+Computes the truth value of `df_i != other_i` for each element `df_i` of the dataframe instance `df` with the respective element `other_i` of the dataframe `other`.
+
+#### Parameters
+
+-   **other**: _&lt;dataframe&gt;_
+
+    -   dataframe. Must be compatible with the dataframe instance (**TODO: broadcasting**).
+
+-   **axis**: _Optional\[ int ]_
+
+    -   axis along which to compare. If equal to `0`, element-wise comparison must be performed over the index. If equal to `1`, element-wise comparison must be performed over the columns. By default, element-wise comparison must be computed over the columns. Default: `None`.
+
+#### Returns
+
+-   **out**: _&lt;dataframe&gt;_
+
+    -   dataframe containing element-wise results. Each element of the returned dataframe must be of type `bool`.


### PR DESCRIPTION
This PR

-   adds specifications for comparison methods.
-   is derived from comparing API [signatures](https://github.com/data-apis/dataframe-api-comparison/tree/296925cb9d88600414c56b7529fbf70e4c54f83e/signatures/comparison) across dataframe libraries.

## Notes

-   Comparison methods are widely implemented across [dataframe libraries](https://github.com/data-apis/dataframe-api-comparison/blob/2dae41fd0bdbd6b135470f640e0281f9315bc013/data/common_apis.csv) and are used by downstream [libraries](https://github.com/data-apis/dataframe-api-comparison/blob/2dae41fd0bdbd6b135470f640e0281f9315bc013/data/common_apis_ranks.csv).

-   For all comparison methods, cuDF hangs the methods on a `Series` object, but not the `DataFrame` object.

-   For all comparison methods, cuDF and Koalas do not support the `axis` keyword. The `axis` keyword is not currently included in this proposal (see note on broadcasting below).

-   For all comparison methods, cuDF and Koalas do not support the `level` keyword.

-   Pandas, Dask, Modin are liberal in what they accept (e.g., scalar, sequence, Series, DataFrame). This PR limits to DataFrame objects, similar to the array API specification. This choice should be discussed and confirmed.

-   As a follow-up to the prior note, this PR does not currently address broadcasting semantics. A few notes on this end:

    -   Similar to the array API specification, scalars can be broadcast as an MxN dataframe whose size matches the original dataframe. And similar to the array API specification, how libraries choose to represent a scalar as an MxN dataframe can be implementation-defined.
    -   A dataframe consisting of a single row (size: 1xN) can be broadcast as an MxN dataframe whose size matches the original dataframe.
    -   A dataframe consisting of a single column (size: Mx1) can be broadcast as an MxN dataframe whose size matches the original dataframe.
    -   Otherwise, the dataframe provided as `other` must have a size equal to the original dataframe (i.e., no broadcasting required).