### PR TITLE
Add _format_str mapping to interchange protocol

### DIFF
--- a/protocol/pandas_implementation.py
+++ b/protocol/pandas_implementation.py
@@ -902,6 +902,12 @@ def test_metadata():
     assert_dataframe_equal(df.__dataframe__(), df)
     tm.assert_frame_equal(df, df2)
 
+def test_fromat_str():
+    df = pd.DataFrame(data=dict(a=[1, 2, 3], B=[3, 4, 5],
+                                c=[1.5, 2.5, 3.5], D=["a", "b", "cdef"]))
+    df["B"] = df["B"].astype("category")
+    df["D"] = df["D"].astype("object")
+    df2 = from_dataframe(df)
 
 if __name__ == '__main__':
     test_categorical_dtype()

--- a/protocol/pandas_implementation.py
+++ b/protocol/pandas_implementation.py
@@ -907,7 +907,11 @@ def test_fromat_str():
                                 c=[1.5, 2.5, 3.5], D=["a", "b", "cdef"]))
     df["B"] = df["B"].astype("category")
     df["D"] = df["D"].astype("object")
-    df2 = from_dataframe(df)
+    
+    format_strings = {'a': 'l', 'B': 'U', 'c': 'g', 'D': 'u'}
+    for col in df.columns.tolist():
+        column = _PandasColumn(df[col])
+        assert column.dtype[2] == format_strings[col]
 
 if __name__ == '__main__':
     test_categorical_dtype()


### PR DESCRIPTION
This PR is a proposal to fix issue https://github.com/data-apis/dataframe-api/issues/54:
method `_format_str` was added to `_PandasColumn` with mapping of basic string formats from NumPy to Apache Arrow C Data Interface.

cc @kshitij12345 @rgommers 