### PR TITLE
Refactoring propositions

### DIFF
--- a/protocol/pandas_implementation.py
+++ b/protocol/pandas_implementation.py
@@ -97,6 +97,16 @@ class _DtypeKind(enum.IntEnum):
     DATETIME = 22
     CATEGORICAL = 23
 
+class _Device(enum.IntEnum):
+    CPU = 1
+    CUDA = 2
+    CPU_PINNED = 3
+    OPENCL = 4
+    VULKAN = 7
+    METAL = 8
+    VPI = 9
+    ROCM = 10
+
 _INTS = {8: np.int8, 16: np.int16, 32: np.int32, 64: np.int64}
 _UNITS = {8: np.uint8, 16: np.uint16, 32: np.uint32, 64: np.uint64}
 _FLOATS = {32: np.float32, 64: np.float64}
@@ -311,10 +321,7 @@ class _PandasBuffer:
         """
         Device type and device ID for where the data in the buffer resides.
         """
-        class Device(enum.IntEnum):
-            CPU = 1
-
-        return (Device.CPU, None)
+        return (_Device.CPU, None)
 
     def __repr__(self) -> str:
         return 'PandasBuffer(' + str({'bufsize': self.bufsize,


### PR DESCRIPTION
I've made a few changes based on the feedback from the [cudf implementation PR](https://github.com/rapidsai/cudf/pull/9071#issuecomment-950140232) I've submit still under review.
There  3 main refactoring (one for each commit):

1. The first part of the `buffer_to_ndarray` method is convert the protocol dtype to numpy one. I've refactored it in a dedicated method as in cudf implementation, I needed it a dozen of times so this might be the case for pandas in near future. Also this method used some local constants that I've moved into module level constant. This will prevent to recreate these variables for each call.
2. I've moved the Device class from the`__dlpack_device__` method to the module level as `_DtypeKind`. Then I've add all the devices values so that the code will show which are currently support and maintainers will know directly about future device supports.
3. I've noticed that `convert_string_column` return all buffers while `buffer_to_ndarray` and `convert_categorical_column` return only the data buffer. So I've set these latter to return all buffers as well.

