### PR TITLE
Fix Design Requirements typo

### DIFF
--- a/protocol/design_requirements.md
+++ b/protocol/design_requirements.md
@@ -118,7 +118,7 @@ We'll also list some things that were discussed but are not requirements:
    interleaved array in NumPy._
 
 3. Extension dtypes, i.e. a way to extend the set of dtypes that is
-   explicitly support, are out of scope.
+   explicitly supported, are out of scope.
 
    _Rationale: complex to support, not used enough to justify that complexity._
 


### PR DESCRIPTION
'explicitly supported'* not 'support'
