### PR TITLE
Clarify that chunks in `__dataframe__` are equal-size across columns

### DIFF
--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -494,5 +494,8 @@ class DataFrame(ABC):
         producer. If given, ``n_chunks`` must be a multiple of
         ``self.num_chunks()``, meaning the producer must subdivide each chunk
         before yielding it.
+
+        Note that the producer must ensure that all columns are chunked the
+        same way.
         """
         pass


### PR DESCRIPTION
This follows up on https://github.com/data-apis/dataframe-api/pull/35#issuecomment-1179154887