### PR TITLE
Clarify dtype type in `ColumnBuffers`  elements

### DIFF
--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -58,6 +58,9 @@ class DtypeKind(enum.IntEnum):
     CATEGORICAL = 23
 
 
+Dtype = Tuple[DtypeKind, int, str, str]
+
+
 class ColumnNullType(enum.IntEnum):
     """
     Integer enum for null type representation.
@@ -91,7 +94,7 @@ class ColumnBuffers(TypedDict):
     # first element is a buffer containing mask values indicating missing data;
     # second element is the mask value buffer's associated dtype.
     # None if the null representation is not a bit or byte mask
-    validity: Optional[Tuple["Buffer", Any]]
+    validity: Optional[Tuple["Buffer", Dtype]]
 
     # first element is a buffer containing the offset values for
     # variable-size binary data (e.g., variable-length strings);
@@ -237,7 +240,7 @@ class Column(ABC):
 
     @property
     @abstractmethod
-    def dtype(self) -> Tuple[DtypeKind, int, str, str]:
+    def dtype(self) -> Dtype:
         """
         Dtype description as a tuple ``(kind, bit-width, format string, endianness)``.
 

--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -89,7 +89,7 @@ class ColumnNullType(enum.IntEnum):
 class ColumnBuffers(TypedDict):
     # first element is a buffer containing the column data;
     # second element is the data buffer's associated dtype
-    data: Tuple["Buffer", Any]
+    data: Tuple["Buffer", Dtype]
 
     # first element is a buffer containing mask values indicating missing data;
     # second element is the mask value buffer's associated dtype.
@@ -100,7 +100,7 @@ class ColumnBuffers(TypedDict):
     # variable-size binary data (e.g., variable-length strings);
     # second element is the offsets buffer's associated dtype.
     # None if the data buffer does not have an associated offsets buffer
-    offsets: Optional[Tuple["Buffer", Any]]
+    offsets: Optional[Tuple["Buffer", Dtype]]
 
 
 class CategoricalDescription(TypedDict):

--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -58,7 +58,7 @@ class DtypeKind(enum.IntEnum):
     CATEGORICAL = 23
 
 
-Dtype = Tuple[DtypeKind, int, str, str]
+Dtype = Tuple[DtypeKind, int, str, str]  # see Column.dtype
 
 
 class ColumnNullType(enum.IntEnum):


### PR DESCRIPTION
Thanks for this team's efforts in implementing the dataframe interchange protocol.

While experimenting on an implementation for StaticFrame (https://github.com/InvestmentSystems/static-frame/pull/621), I found one aspect of the ABC and associated types unclear.

The `ColumnBuffers` `TypedDict` defines its elements as pairs of `Buffer` and a dtype, but only types the dtype as `Any`. I assume that the dtype should be provided as the same tuple returned from `Column.dtype`. This PR makes this explicit by defining a `Dtype` type alias and using it for the return value of `Column.dtype` as well as the elements in `ColumnBuffers`.

If my assumption is incorrect, it would be helpful to specify the type of the dtype values returned from `ColumnBuffers`. 
