### PR TITLE
Update groupby docstring to make orderedness explicitly not guaranteed

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -11,9 +11,27 @@ __all__ = ["DataFrame"]
 
 
 class DataFrame:
-    def groupby(self, keys: list[str], /) -> GroupBy:
+    def groupby(self, keys: Sequence[str], /) -> GroupBy:
         """
         Group the DataFrame by the given columns.
+
+        Parameters
+        ----------
+        keys : Sequence[str]
+
+        Returns
+        -------
+        GroupBy
+
+        Raises
+        ------
+        KeyError
+            If any of the requested keys are not present.
+
+        Notes
+        -----
+        The order of the keys and the order of rows within each group is not
+        guaranteed and is implementation defined.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -30,8 +30,9 @@ class DataFrame:
 
         Notes
         -----
-        The order of the keys and the order of rows within each group is not
-        guaranteed and is implementation defined.
+        Downstream operations from this function, like aggregations, return
+        results for which row order is not guaranteed and is implementation
+        defined.
         """
         ...
 


### PR DESCRIPTION
Updates the `DataFrame.groupby` docstring to clarify that orderdedness of both keys and rows within each group is not guaranteed and is implementation defined.

Additionally, changes keys to be a `Sequence[str]` to be in line with other APIs expecting a sequence of column names.
