### PR TITLE
Fix the Circle CI preview link on PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,6 +11,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLE_TOKEN }}
           artifact-path: 0/build/draft/index.html
           circleci-jobs: build_page
           job-title: Check the rendered docs here!


### PR DESCRIPTION
The added token has to be a personal token; I generated that within the CircleCI app.