### PR TITLE
Add `null` object, and update top-level API specification

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -88,7 +88,7 @@ class null:
     TypeError
         From ``__eq__`` and from ``__bool__``.
 
-        For ``_eq__``: a missing value must not be compared for equality
+        For ``__eq__``: a missing value must not be compared for equality
         directly. Instead, use `DataFrame.isnull` or `Column.isnull` to check
         for presence of missing values.
 

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -14,8 +14,9 @@ from ._types import DType
 
 __dataframe_api_version__: str = "YYYY.MM"
 """
-String representing the version of the DataFrame API specification to which the
-conforming implementation adheres.
+String representing the version of the DataFrame API specification to which
+the conforming implementation adheres. Set to a concrete value for a stable
+implementation of the dataframe API standard.
 """
 
 def concat(dataframes: Sequence[DataFrame]) -> DataFrame:
@@ -73,3 +74,36 @@ def dataframe_from_dict(data: Mapping[str, Column]) -> DataFrame:
     DataFrame
     """
     ...
+
+class null:
+    """
+    A `null` singleton object to represent missing data.
+
+    ``null`` may be used when constructing a `Column` from a Python sequence.
+    It supports ``is``, and does not support ``==`` and ``bool``.
+
+    Methods
+    -------
+    __bool__
+    __eq__
+
+    """
+    def __eq__(self):
+        """
+        Raises
+        ------
+        RuntimeError
+            A missing value must not be compared for equality. Use ``is`` to check
+            if an object *is* this ``null`` object, and `DataFrame.isnull` or
+            `Column.isnull` to check for presence of missing values.
+        """
+        ...
+
+    def __bool__(self):
+        """
+        Raises
+        ------
+        TypeError
+            Truthiness of a missing value is ambiguous
+        """
+        ...

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -3,7 +3,7 @@ Function stubs and API documentation for the DataFrame API standard.
 """
 from __future__ import annotations
 
-from typing import Mapping, Sequence
+from typing import Mapping, Sequence, Any
 
 from .column_object import *
 from .dataframe_object import *
@@ -102,3 +102,20 @@ class null:
 
     """
     ...
+
+def isnull(value: Any, /) -> bool:
+    """
+    Check if an object is a `null` scalar.
+
+    Parameters
+    ----------
+    value : Any
+        Any input type is valid.
+
+    Returns
+    -------
+    bool
+        True if the input is a `null` object from the same library which
+        implements the dataframe API standard, False otherwise.
+
+    """

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -77,33 +77,28 @@ def dataframe_from_dict(data: Mapping[str, Column]) -> DataFrame:
 
 class null:
     """
-    A `null` singleton object to represent missing data.
+    A `null` object to represent missing data.
 
-    ``null`` may be used when constructing a `Column` from a Python sequence.
-    It supports ``is``, and does not support ``==`` and ``bool``.
+    ``null`` is a scalar, and may be used when constructing a `Column` from a
+    Python sequence with `column_from_sequence`. It does not support ``is``,
+    ``==`` or ``bool``.
 
-    Methods
-    -------
-    __bool__
-    __eq__
+    Raises
+    ------
+    TypeError
+        From ``__eq__`` and from ``__bool__``.
+
+        For ``_eq__``: a missing value must not be compared for equality
+        directly. Instead, use `DataFrame.isnull` or `Column.isnull` to check
+        for presence of missing values.
+
+        For ``__bool__``: truthiness of a missing value is ambiguous.
+
+    Notes
+    -----
+    Like for Python scalars, the ``null`` object may be duck typed so it can
+    reside on (e.g.) a GPU. Hence, the builtin ``is`` keyword should not be
+    used to check if an object *is* the ``null`` object.
 
     """
-    def __eq__(self):
-        """
-        Raises
-        ------
-        RuntimeError
-            A missing value must not be compared for equality. Use ``is`` to check
-            if an object *is* this ``null`` object, and `DataFrame.isnull` or
-            `Column.isnull` to check for presence of missing values.
-        """
-        ...
-
-    def __bool__(self):
-        """
-        Raises
-        ------
-        TypeError
-            Truthiness of a missing value is ambiguous
-        """
-        ...
+    ...

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -103,13 +103,13 @@ class null:
     """
     ...
 
-def isnull(value: Any, /) -> bool:
+def isnull(value: object, /) -> bool:
     """
     Check if an object is a `null` scalar.
 
     Parameters
     ----------
-    value : Any
+    value : object
         Any input type is valid.
 
     Returns

--- a/spec/API_specification/index.rst
+++ b/spec/API_specification/index.rst
@@ -5,6 +5,20 @@ API specification
 
 .. currentmodule:: dataframe_api
 
+The API consists of dataframe, column and groupby classes, plus a small number
+of objects and functions in the top-level namespace. The latter are:
+
+.. autosummary::
+   :toctree: generated
+   :template: attribute.rst
+   :nosignatures:
+
+   __dataframe_api_version__
+   null
+
+The ``DataFrame``, ``Column`` and ``GroupBy`` objects have the following
+methods and attributes:
+
 .. toctree::
    :maxdepth: 3
 

--- a/spec/API_specification/index.rst
+++ b/spec/API_specification/index.rst
@@ -14,6 +14,7 @@ of objects and functions in the top-level namespace. The latter are:
    :nosignatures:
 
    __dataframe_api_version__
+   isnull
    null
 
 The ``DataFrame``, ``Column`` and ``GroupBy`` objects have the following


### PR DESCRIPTION
Also includes `__dataframe_api_version__`, which was already present, into the API specification.

The table of top-level objects/functions will remain pretty sparse, but there's probably a few more things that need adding. `concat` for one, see gh-137.

I'll note that I briefly considered whether this should be spelled `NULL` or `Null`, but went with `null` because that seemed most natural (e.g., `DataFrame.from_sequence([1, 2, null, np.nan]`).