### PR TITLE
Add a `fill_nan` method to dataframe and column

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -12,6 +12,16 @@ from .groupby_object import *
 from ._types import DType
 
 
+__all__ = [
+    "__dataframe_api_version",
+    "column_from_sequence",
+    "concat",
+    "dataframe_from_dict",
+    "isnull",
+    "null",
+]
+
+
 __dataframe_api_version__: str = "YYYY.MM"
 """
 String representing the version of the DataFrame API specification to which

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -456,3 +456,17 @@ class Column:
         To get the unique values, you can do ``col.get_rows(col.unique_indices())``.
         """
         ...
+
+    def fill_nan(self, value: float | null, /):
+        """
+        Fill floating point ``nan`` values with the given fill value.
+
+        Parameters
+        ----------
+        value : float or `null`
+            Value used to replace any ``nan`` in the column with. Must be
+            of the Python scalar type matching the dtype of the column (or
+            be `null`).
+
+        """
+        ...

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -457,7 +457,7 @@ class Column:
         """
         ...
 
-    def fill_nan(self, value: float | null, /):
+    def fill_nan(self, value: float | 'null', /):
         """
         Fill floating point ``nan`` values with the given fill value.
 

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -457,7 +457,7 @@ class Column:
         """
         ...
 
-    def fill_nan(self, value: float | 'null', /):
+    def fill_nan(self, value: float | 'null', /) -> Column:
         """
         Fill floating point ``nan`` values with the given fill value.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -707,7 +707,7 @@ class DataFrame:
         """
         ...
 
-    def fill_nan(self, value: float | null, /):
+    def fill_nan(self, value: float | 'null', /):
         """
         Fill ``nan`` values with the given fill value.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -707,7 +707,7 @@ class DataFrame:
         """
         ...
 
-    def fill_nan(self, value: float | 'null', /):
+    def fill_nan(self, value: float | 'null', /) -> DataFrame:
         """
         Fill ``nan`` values with the given fill value.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -706,3 +706,20 @@ class DataFrame:
         In particular, does not check for `np.timedelta64('NaT')`.
         """
         ...
+
+    def fill_nan(self, value: float | null, /):
+        """
+        Fill ``nan`` values with the given fill value.
+
+        The fill operation will apply to all columns with a floating-point
+        dtype. Other columns remain unchanged.
+
+        Parameters
+        ----------
+        value : float or `null`
+            Value used to replace any ``nan`` in the column with. Must be
+            of the Python scalar type matching the dtype of the column (or
+            be `null`.
+
+        """
+        ...

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -719,7 +719,7 @@ class DataFrame:
         value : float or `null`
             Value used to replace any ``nan`` in the column with. Must be
             of the Python scalar type matching the dtype of the column (or
-            be `null`.
+            be `null`).
 
         """
         ...


### PR DESCRIPTION
Addresses half of gh-142 (`fill_null` is more complex, and not included here).

*Note: this is reviewable now, but should be merged after gh-157 which introduces the `null` object).*