### PR TITLE
add `Column.__dataframe_namespace__`

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NoReturn, Sequence, TYPE_CHECKING
+from typing import Any, NoReturn, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._types import Scalar, DType
@@ -18,6 +18,34 @@ class Column:
     constructor functions or an already-created dataframe object retrieved via
 
     """
+
+    def __dataframe_namespace__(
+        self: Column, /, *, api_version: str | None = None
+    ) -> Any:
+        """
+        Returns an object that has all the dataframe API functions on it.
+
+        Parameters
+        ----------
+        api_version: Optional[str]
+            String representing the version of the dataframe API specification
+            to be returned, in ``'YYYY.MM'`` form, for example, ``'2023.04'``.
+            If it is ``None``, it should return the namespace corresponding to
+            latest version of the dataframe API specification.  If the given
+            version is invalid or not implemented for the given module, an
+            error should be raised. Default: ``None``.
+
+        Returns
+        -------
+        namespace: Any
+            An object representing the dataframe API namespace. It should have
+            every top-level function defined in the specification as an
+            attribute. It may contain other public names as well, but it is
+            recommended to only include those names that are part of the
+            specification.
+
+        """
+
     def __len__(self) -> int:
         """
         Return the number of rows.

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -19,11 +19,11 @@ class Column:
 
     """
 
-    def __dataframe_namespace__(
+    def __column_namespace__(
         self: Column, /, *, api_version: str | None = None
     ) -> Any:
         """
-        Returns an object that has all the dataframe API functions on it.
+        Returns an object that has all the Dataframe Standard API functions on it.
 
         Parameters
         ----------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Mapping, Sequence, Union, TYPE_CHECKING, NoReturn
+from typing import Any, Literal, Mapping, Sequence, Union, TYPE_CHECKING, NoReturn
 
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ class DataFrame:
 
     """
     def __dataframe_namespace__(
-        self: DataFrame, /, *, api_version: Optional[str] = None
+        self: DataFrame, /, *, api_version: str | None = None
     ) -> Any:
         """
         Returns an object that has all the dataframe API functions on it.


### PR DESCRIPTION
Pretty minor, hope this is uncontroversial

use-case: you have a function which accepts a Column as input, and you need to access some method from the top-level namespace