### PR TITLE
remove from_dict

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -63,23 +63,6 @@ class DataFrame:
 
         """
 
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Column]) -> DataFrame:
-        """
-        Construct DataFrame from map of column names to Columns.
-
-        Parameters
-        ----------
-        data : Mapping[str, Column]
-            Column must be of the corresponding type of the DataFrame.
-            For example, it is only supported to build a ``LibraryXDataFrame`` using
-            ``LibraryXColumn`` instances.
-
-        Returns
-        -------
-        DataFrame
-        """
-
     @property
     def dataframe(self) -> object:
         """


### PR DESCRIPTION
there's already namespace.dataframe_from_dict, let's not repeat the same "1000 ways to do the same thing" there is in pandas