### PR TITLE
Add some cumulative Column operations

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -525,26 +525,26 @@ class Column:
             Whether to skip null values.
         """
 
-    def cummax(self) -> Column:
+    def cumulative_max(self) -> Column:
         """
         Reduction returns a Column. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def cummin(self) -> Column:
+    def cumulative_min(self) -> Column:
         """
         Reduction returns a Column. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def cumsum(self) -> Column:
+    def cumulative_sum(self) -> Column:
         """
         Reduction returns a Column. Must be supported for numerical and
         datetime data types. The returned value has the same dtype as the
         column.
         """
 
-    def cumprod(self) -> Column:
+    def cumulative_prod(self) -> Column:
         """
         Reduction returns a Column. Must be supported for numerical and
         datetime data types. The returned value has the same dtype as the

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -498,6 +498,32 @@ class Column:
         dtypes.
         """
 
+    def cummax(self) -> Column:
+        """
+        Reduction returns a Column. Any data type that supports comparisons
+        must be supported. The returned value has the same dtype as the column.
+        """
+
+    def cummin(self) -> Column:
+        """
+        Reduction returns a Column. Any data type that supports comparisons
+        must be supported. The returned value has the same dtype as the column.
+        """
+
+    def cumsum(self) -> Column:
+        """
+        Reduction returns a Column. Must be supported for numerical and
+        datetime data types. The returned value has the same dtype as the
+        column.
+        """
+
+    def cumprod(self) -> Column:
+        """
+        Reduction returns a Column. Must be supported for numerical and
+        datetime data types. The returned value has the same dtype as the
+        column.
+        """
+
     def is_null(self) -> Column:
         """
         Check for 'missing' or 'null' entries.


### PR DESCRIPTION
I noticed plotly uses some cumulative functions (`Series.cumsum`) - OK to start adding some simple and common cumulative operations to `Column`?