### PR TITLE
Add DataFrame.to_array_object and Column.to_array_object

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -700,3 +700,25 @@ class Column(Generic[DType]):
 
         """
         ...
+
+    def to_array_object(self, dtype: Any) -> Any:
+        """
+        Convert to array-API-compliant object.
+
+        Parameters
+        ----------
+        dtype : Any
+            The dtype of the array-API-compliant object to return.
+        
+        Returns
+        -------
+        Any
+            An array-API-compliant object.
+        
+        Notes
+        -----
+        While numpy arrays are not yet array-API-compliant, implementations
+        may choose to return a numpy array (for numpy prior to 2.0), with the
+        understanding that consuming libraries would then use the
+        ``array-api-compat`` package to convert it to a Standard-compliant array.
+        """

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -828,3 +828,25 @@ class DataFrame:
 
         """
         ...
+    
+    def to_array_object(self, dtype: Any) -> Any:
+        """
+        Convert to array-API-compliant object.
+
+        Parameters
+        ----------
+        dtype : Any
+            The dtype of the array-API-compliant object to return.
+        
+        Returns
+        -------
+        Any
+            An array-API-compliant object.
+        
+        Notes
+        -----
+        While numpy arrays are not yet array-API-compliant, implementations
+        may choose to return a numpy array (for numpy prior to 2.0), with the
+        understanding that consuming libraries would then use the
+        ``array-api-compat`` package to convert it to a Standard-compliant array.
+        """


### PR DESCRIPTION
Trying to move this forwards, according to my understanding

Sorry if I've misunderstood the

>         While numpy arrays are not yet array-API-compliant, implementations
>        may choose to return a numpy array (for numpy prior to 2.0), with the
>        understanding that consuming libraries would then use the
>        ``array-api-compat`` package to convert it to a Standard-compliant array.

part