### PR TITLE
let `keys` be none in sorted_indices

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -253,7 +253,7 @@ class DataFrame:
 
     def sorted_indices(
         self,
-        keys: Sequence[str],
+        keys: Sequence[str] | None = None,
         *,
         ascending: Sequence[bool] | bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
@@ -267,8 +267,9 @@ class DataFrame:
 
         Parameters
         ----------
-        keys : Sequence[str]
+        keys : Sequence[str] | None
             Names of columns to sort by.
+            If `None`, sort by all columns.
         ascending : Sequence[bool] or bool
             If `True`, sort by all keys in ascending order.
             If `False`, sort by all keys in descending order.


### PR DESCRIPTION
a few other methods allow this (`unique_indices`, `fill_null`) so we should probably add it here too