### PR TITLE
to_array_object: type dtype as str, note possibilities

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -699,17 +699,17 @@ class Column(Generic[DType]):
             The dtype of the array-API-compliant object to return.
             Must be one of:
 
-            - namespace.Bool()
-            - namespace.Int8()
-            - namespace.Int16()
-            - namespace.Int32()
-            - namespace.Int64()
-            - namespace.UInt8()
-            - namespace.UInt16()
-            - namespace.UInt32()
-            - namespace.UInt64()
-            - namespace.Float32()
-            - namespace.Float64()
+            - Bool()
+            - Int8()
+            - Int16()
+            - Int32()
+            - Int64()
+            - UInt8()
+            - UInt16()
+            - UInt32()
+            - UInt64()
+            - Float32()
+            - Float64()
         
         Returns
         -------

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -701,27 +701,27 @@ class Column(Generic[DType]):
         """
         ...
 
-    def to_array_object(self, dtype: str) -> Any:
+    def to_array_object(self, dtype: Any) -> Any:
         """
         Convert to array-API-compliant object.
 
         Parameters
         ----------
-        dtype : str
+        dtype : DType
             The dtype of the array-API-compliant object to return.
             Must be one of:
 
-            - bool
-            - int8
-            - int16
-            - int32
-            - int64
-            - uint8
-            - uint16
-            - uint32
-            - uint64
-            - float32
-            - float64
+            - namespace.Bool()
+            - namespace.Int8()
+            - namespace.Int16()
+            - namespace.Int32()
+            - namespace.Int64()
+            - namespace.UInt8()
+            - namespace.UInt16()
+            - namespace.UInt32()
+            - namespace.UInt64()
+            - namespace.Float32()
+            - namespace.Float64()
         
         Returns
         -------

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -701,14 +701,27 @@ class Column(Generic[DType]):
         """
         ...
 
-    def to_array_object(self, dtype: Any) -> Any:
+    def to_array_object(self, dtype: str) -> Any:
         """
         Convert to array-API-compliant object.
 
         Parameters
         ----------
-        dtype : Any
+        dtype : str
             The dtype of the array-API-compliant object to return.
+            Must be one of:
+
+            - bool
+            - int8
+            - int16
+            - int32
+            - int64
+            - uint8
+            - uint16
+            - uint32
+            - uint64
+            - float32
+            - float64
         
         Returns
         -------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -827,17 +827,17 @@ class DataFrame:
             The dtype of the array-API-compliant object to return:
             Must be one of:
 
-            - namespace.Bool()
-            - namespace.Int8()
-            - namespace.Int16()
-            - namespace.Int32()
-            - namespace.Int64()
-            - namespace.UInt8()
-            - namespace.UInt16()
-            - namespace.UInt32()
-            - namespace.UInt64()
-            - namespace.Float32()
-            - namespace.Float64()
+            - Bool()
+            - Int8()
+            - Int16()
+            - Int32()
+            - Int64()
+            - UInt8()
+            - UInt16()
+            - UInt32()
+            - UInt64()
+            - Float32()
+            - Float64()
         
         Returns
         -------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -817,27 +817,27 @@ class DataFrame:
         """
         ...
     
-    def to_array_object(self, dtype: str) -> Any:
+    def to_array_object(self, dtype: Any) -> Any:
         """
         Convert to array-API-compliant object.
 
         Parameters
         ----------
-        dtype : str
+        dtype : DType
             The dtype of the array-API-compliant object to return:
             Must be one of:
 
-            - bool
-            - int8
-            - int16
-            - int32
-            - int64
-            - uint8
-            - uint16
-            - uint32
-            - uint64
-            - float32
-            - float64
+            - namespace.Bool()
+            - namespace.Int8()
+            - namespace.Int16()
+            - namespace.Int32()
+            - namespace.Int64()
+            - namespace.UInt8()
+            - namespace.UInt16()
+            - namespace.UInt32()
+            - namespace.UInt64()
+            - namespace.Float32()
+            - namespace.Float64()
         
         Returns
         -------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -824,7 +824,7 @@ class DataFrame:
         Parameters
         ----------
         dtype : DType
-            The dtype of the array-API-compliant object to return:
+            The dtype of the array-API-compliant object to return.
             Must be one of:
 
             - Bool()

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -817,14 +817,27 @@ class DataFrame:
         """
         ...
     
-    def to_array_object(self, dtype: Any) -> Any:
+    def to_array_object(self, dtype: str) -> Any:
         """
         Convert to array-API-compliant object.
 
         Parameters
         ----------
-        dtype : Any
-            The dtype of the array-API-compliant object to return.
+        dtype : str
+            The dtype of the array-API-compliant object to return:
+            Must be one of:
+
+            - bool
+            - int8
+            - int16
+            - int32
+            - int64
+            - uint8
+            - uint16
+            - uint32
+            - uint64
+            - float32
+            - float64
         
         Returns
         -------


### PR DESCRIPTION
not all dataframe dtypes are supported by the array api (e.g. `datetime`), so just accepting the same ones and sometimes raising `NotImplementedError` may not be the best experience

How about just accepting `str`, and listing the allowed strings? These dtypes don't need to store anything (like categories / time unit / time zone), so don't need to be classes anyway.
Internally, each implementation can map to the correct object (e.g. for pandas: 'int64' would go to np.int64)