### PR TITLE
Rename entrypoints to `__dataframe_consortium_standard__` and `__column_consortium_standard__`

### DIFF
--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -361,11 +361,11 @@ the level of (non-)conformance. For details on how to do this, see
 
 Libraries which implement the Standard in a separate namespace
 are required to provide the following methods:
-- ``__dataframe_standard__``: used for converting a non-compliant dataframe to a compliant one;
-- ``__column_standard__``: used for converting a non-compliant column to a compliant one.
+- ``__dataframe_consortium_standard__``: used for converting a non-compliant dataframe to a compliant one;
+- ``__column_consortium_standard__``: used for converting a non-compliant column to a compliant one.
 
-For example, pandas would have ``pandas.DataFrame.__dataframe_standard__`` and
-``pandas.Series.__column_standard__``.
+For example, pandas would have ``pandas.DataFrame.__dataframe_consortium_standard__`` and
+``pandas.Series.__column_consortium_standard__``.
 
 The signatures should be (note: docstring is optional):
 ```python


### PR DESCRIPTION
Renaming to make this more amenable to pandas