### PR TITLE
Fix up some return types for methods with `skip_nulls`

### DIFF
--- a/spec/API_specification/dataframe_api/_types.py
+++ b/spec/API_specification/dataframe_api/_types.py
@@ -23,6 +23,9 @@ from enum import Enum
 # Type alias: Mypy needs Any, but for readability we need to make clear this
 # is a Python scalar (i.e., an instance of `bool`, `int`, `float`, `str`, etc.)
 Scalar = Any
+# null is a special object which represents a missing value.
+# It is not valid as a type.
+NullType = Any
 
 array = TypeVar("array")
 device = TypeVar("device")

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -5,8 +5,8 @@ from typing import Any,NoReturn, TYPE_CHECKING, Literal, Generic
 from ._types import DType
 
 if TYPE_CHECKING:
-    from . import Bool, null
-    from ._types import Scalar
+    from . import Bool
+    from ._types import NullType, Scalar
 
 
 __all__ = ['Column']
@@ -467,7 +467,7 @@ class Column(Generic[DType]):
             If any of the Column's columns is not boolean.
         """
 
-    def any(self: Column[Bool], *, skip_nulls: bool = True) -> bool | null:
+    def any(self: Column[Bool], *, skip_nulls: bool = True) -> bool | NullType:
         """
         Reduction returns a bool.
 
@@ -477,7 +477,7 @@ class Column(Generic[DType]):
             If column is not boolean.
         """
 
-    def all(self: Column[Bool], *, skip_nulls: bool = True) -> bool | null:
+    def all(self: Column[Bool], *, skip_nulls: bool = True) -> bool | NullType:
         """
         Reduction returns a bool.
 
@@ -487,32 +487,32 @@ class Column(Generic[DType]):
             If column is not boolean.
         """
 
-    def min(self, *, skip_nulls: bool = True) -> Scalar | null:
+    def min(self, *, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def max(self, *, skip_nulls: bool = True) -> Scalar | null:
+    def max(self, *, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def sum(self, *, skip_nulls: bool = True) -> Scalar | null:
+    def sum(self, *, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. The returned value has the same dtype as the
         column.
         """
 
-    def prod(self, *, skip_nulls: bool = True) -> Scalar | null:
+    def prod(self, *, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Must be supported for numerical data types.
         The returned value has the same dtype as the column.
         """
 
-    def median(self, *, skip_nulls: bool = True) -> Scalar | null:
+    def median(self, *, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -520,7 +520,7 @@ class Column(Generic[DType]):
         dtypes.
         """
 
-    def mean(self, *, skip_nulls: bool = True) -> Scalar | null:
+    def mean(self, *, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -528,7 +528,7 @@ class Column(Generic[DType]):
         dtypes.
         """
 
-    def std(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar | null:
+    def std(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -554,7 +554,7 @@ class Column(Generic[DType]):
             Whether to skip null values.
         """
 
-    def var(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar | null:
+    def var(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar | NullType:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -674,7 +674,7 @@ class Column(Generic[DType]):
         """
         ...
 
-    def fill_nan(self: Column[DType], value: float | null, /) -> Column[DType]:
+    def fill_nan(self: Column[DType], value: float | NullType, /) -> Column[DType]:
         """
         Fill floating point ``nan`` values with the given fill value.
 

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any,NoReturn, Sequence, TYPE_CHECKING, Literal, Generic
+from typing import Any,NoReturn, TYPE_CHECKING, Literal, Generic
 
 from ._types import DType
 

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -467,7 +467,7 @@ class Column(Generic[DType]):
             If any of the Column's columns is not boolean.
         """
 
-    def any(self: Column[Bool], *, skip_nulls: bool = True) -> bool:
+    def any(self: Column[Bool], *, skip_nulls: bool = True) -> bool | null:
         """
         Reduction returns a bool.
 
@@ -477,7 +477,7 @@ class Column(Generic[DType]):
             If column is not boolean.
         """
 
-    def all(self: Column[Bool], *, skip_nulls: bool = True) -> bool:
+    def all(self: Column[Bool], *, skip_nulls: bool = True) -> bool | null:
         """
         Reduction returns a bool.
 
@@ -487,32 +487,32 @@ class Column(Generic[DType]):
             If column is not boolean.
         """
 
-    def min(self, *, skip_nulls: bool = True) -> Scalar:
+    def min(self, *, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def max(self, *, skip_nulls: bool = True) -> Scalar:
+    def max(self, *, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def sum(self, *, skip_nulls: bool = True) -> Scalar:
+    def sum(self, *, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. The returned value has the same dtype as the
         column.
         """
 
-    def prod(self, *, skip_nulls: bool = True) -> Scalar:
+    def prod(self, *, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Must be supported for numerical data types.
         The returned value has the same dtype as the column.
         """
 
-    def median(self, *, skip_nulls: bool = True) -> Scalar:
+    def median(self, *, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -520,7 +520,7 @@ class Column(Generic[DType]):
         dtypes.
         """
 
-    def mean(self, *, skip_nulls: bool = True) -> Scalar:
+    def mean(self, *, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -528,7 +528,7 @@ class Column(Generic[DType]):
         dtypes.
         """
 
-    def std(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar:
+    def std(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -554,7 +554,7 @@ class Column(Generic[DType]):
             Whether to skip null values.
         """
 
-    def var(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar:
+    def var(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Scalar | null:
         """
         Reduction returns a scalar. Must be supported for numerical and
         datetime data types. Returns a float for numerical data types, and
@@ -674,7 +674,7 @@ class Column(Generic[DType]):
         """
         ...
 
-    def fill_nan(self: Column[DType], value: float | 'null', /) -> Column[DType]:
+    def fill_nan(self: Column[DType], value: float | null, /) -> Column[DType]:
         """
         Fill floating point ``nan`` values with the given fill value.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -6,8 +6,8 @@ from typing import Any, Literal, Mapping, Sequence, Union, TYPE_CHECKING, NoRetu
 if TYPE_CHECKING:
     from .column_object import Column
     from .groupby_object import GroupBy
-    from . import Bool, null
-    from ._types import Scalar
+    from . import Bool
+    from ._types import NullType, Scalar
 
 
 __all__ = ["DataFrame"]
@@ -768,7 +768,7 @@ class DataFrame:
         """
         ...
 
-    def fill_nan(self, value: float | 'null', /) -> DataFrame:
+    def fill_nan(self, value: float | NullType, /) -> DataFrame:
         """
         Fill ``nan`` values with the given fill value.
 

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -84,7 +84,7 @@ nitpick_ignore = [
     ('py:class', 'Scalar'),
     ('py:class', 'Bool'),
     ('py:class', 'optional'),
-    ('py:class', 'null'),
+    ('py:class', 'NullType'),
 ]
 # NOTE: this alias handling isn't used yet - added in anticipation of future
 #       need based on dataframe API aliases.

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -84,6 +84,7 @@ nitpick_ignore = [
     ('py:class', 'Scalar'),
     ('py:class', 'Bool'),
     ('py:class', 'optional'),
+    ('py:class', 'null'),
 ]
 # NOTE: this alias handling isn't used yet - added in anticipation of future
 #       need based on dataframe API aliases.

--- a/spec/design_topics/python_builtin_types.md
+++ b/spec/design_topics/python_builtin_types.md
@@ -18,7 +18,7 @@ class DataFrame:
         ...
 
 class Column:
-    def mean(self, skip_nulls: bool = True) -> float | null:
+    def mean(self, skip_nulls: bool = True) -> float | NullType:
         ...
 
 larger = df2 > df1.get_column_by_name('foo').mean()

--- a/spec/design_topics/python_builtin_types.md
+++ b/spec/design_topics/python_builtin_types.md
@@ -18,7 +18,7 @@ class DataFrame:
         ...
 
 class Column:
-    def mean(self, skip_nulls: bool = True) -> float:
+    def mean(self, skip_nulls: bool = True) -> float | null:
         ...
 
 larger = df2 > df1.get_column_by_name('foo').mean()


### PR DESCRIPTION
Some column methods can return `null` if `skip_nulls` is `False`, but the return annotations don't currently capture that

~edit: wait, `null` isn't a valid type~ have added `NullType` (but just used internally, it's not exported)