### PR TITLE
Address leftover renaming away from `__dataframe_standard__`

### DIFF
--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -370,11 +370,11 @@ For example, pandas would have ``pandas.DataFrame.__dataframe_consortium_standar
 The signatures should be (note: docstring is optional):
 ```python
 def __dataframe_consortium_standard__(
-    self, /, *, api_version: str | None = None
+    self, *, api_version: str | None = None
 ) -> Any:
 
 def __column_consortium_standard__(
-    self, /, *, api_version: str | None = None
+    self, *, api_version: str | None = None
 ) -> Any:
 ```
 `api_version` is

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -369,11 +369,11 @@ For example, pandas would have ``pandas.DataFrame.__dataframe_consortium_standar
 
 The signatures should be (note: docstring is optional):
 ```python
-def __dataframe_standard__(
+def __dataframe_consortium_standard__(
     self, /, *, api_version: str | None = None
 ) -> Any:
 
-def __column_standard__(
+def __column_consortium_standard__(
     self, /, *, api_version: str | None = None
 ) -> Any:
 ```


### PR DESCRIPTION
Didn't notice these in the other PR (gh-214).