### PR TITLE
add column.rename

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -710,3 +710,18 @@ class Column(Generic[DType]):
         understanding that consuming libraries would then use the
         ``array-api-compat`` package to convert it to a Standard-compliant array.
         """
+
+    def rename(self, name: str | None) -> Column[DType]:
+        """
+        Rename column.
+
+        Parameters
+        ----------
+        name : str
+            New name for column.
+        
+        Returns
+        -------
+        Column
+        """
+        ...


### PR DESCRIPTION
columns can have names, so they probably need a `rename` method to change it?