### PR TITLE
Don't let Column.name be None

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -72,7 +72,7 @@ def column_from_sequence(sequence: Sequence[Any], *, dtype: Any, name: str = '')
         Sequence of elements. Each element must be of the specified
         ``dtype``, the corresponding Python builtin scalar type, or
         coercible to that Python scalar type.
-    name : str
+    name : str, optional (default: '')
         Name of column.
     dtype : DType
         Dtype of result. Must be specified.
@@ -122,7 +122,7 @@ def column_from_1d_array(array: Any, *, dtype: Any, name: str = '') -> Column[An
     ----------
     array : array
         array-API compliant 1D array
-    name : str
+    name : str, optional (default: '')
         Name to give columns.
     dtype : DType
         Dtype of column.

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -62,7 +62,7 @@ def concat(dataframes: Sequence[DataFrame]) -> DataFrame:
     """
     ...
 
-def column_from_sequence(sequence: Sequence[Any], *, name: str, dtype: Any) -> Column[Any]:
+def column_from_sequence(sequence: Sequence[Any], *, dtype: Any, name: str = '') -> Column[Any]:
     """
     Construct Column from sequence of elements.
 
@@ -108,7 +108,7 @@ def dataframe_from_dict(data: Mapping[str, Column[Any]]) -> DataFrame:
     ...
 
 
-def column_from_1d_array(array: Any, *, name: str, dtype: Any) -> Column[Any]:
+def column_from_1d_array(array: Any, *, dtype: Any, name: str = '') -> Column[Any]:
     """
     Construct Column from 1D array.
 

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -62,7 +62,7 @@ def concat(dataframes: Sequence[DataFrame]) -> DataFrame:
     """
     ...
 
-def column_from_sequence(sequence: Sequence[Any], *, name: str | None, dtype: Any) -> Column[Any]:
+def column_from_sequence(sequence: Sequence[Any], *, name: str, dtype: Any) -> Column[Any]:
     """
     Construct Column from sequence of elements.
 
@@ -72,7 +72,7 @@ def column_from_sequence(sequence: Sequence[Any], *, name: str | None, dtype: An
         Sequence of elements. Each element must be of the specified
         ``dtype``, the corresponding Python builtin scalar type, or
         coercible to that Python scalar type.
-    name : str, optional
+    name : str
         Name of column.
     dtype : DType
         Dtype of result. Must be specified.

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -72,7 +72,7 @@ def column_from_sequence(sequence: Sequence[Any], *, dtype: Any, name: str = '')
         Sequence of elements. Each element must be of the specified
         ``dtype``, the corresponding Python builtin scalar type, or
         coercible to that Python scalar type.
-    name : str, optional (default: '')
+    name : str, optional
         Name of column.
     dtype : DType
         Dtype of result. Must be specified.
@@ -122,7 +122,7 @@ def column_from_1d_array(array: Any, *, dtype: Any, name: str = '') -> Column[An
     ----------
     array : array
         array-API compliant 1D array
-    name : str, optional (default: '')
+    name : str, optional
         Name to give columns.
     dtype : DType
         Dtype of column.

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -47,7 +47,7 @@ class Column(Generic[DType]):
         ...
     
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Return name of column."""
 
     def __len__(self) -> int:
@@ -711,7 +711,7 @@ class Column(Generic[DType]):
         ``array-api-compat`` package to convert it to a Standard-compliant array.
         """
 
-    def rename(self, name: str | None) -> Column[DType]:
+    def rename(self, name: str) -> Column[DType]:
         """
         Rename column.
 


### PR DESCRIPTION
Noticed this while updating the polars implementation: their series must have a `str` name, and can't be `None`

We _could_ hack around this in the implemenation, but I think it's easier to just require the name to only be `str`

Afterall:
- if a column is created from a dataframe (e.g. `df.get_column_by_name('foo')`), then its name will be the column name (which has to be `str`)
- if a column is constructed from a sequence or 1d array, then we can require that a `str` `name` be specified

So, `name` will always be `str`