### PR TITLE
Add warning for nan_as_null

### DIFF
--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -397,14 +397,16 @@ class DataFrame(ABC):
         """
         Construct a new exchange object, potentially changing the parameters.
 
-        ``nan_as_null`` is a keyword intended for the consumer to tell the
-        producer to overwrite null values in the data with ``NaN``.
-        It is intended for cases where the consumer does not support the bit
-        mask or byte mask that is the producer's native representation.
+        ``nan_as_null`` is a DEPRECATED keyword that should not be used. See warning
+        below.
         ``allow_copy`` is a keyword that defines whether or not the library is
         allowed to make a copy of the data. For example, copying data would be
         necessary if a library supports strided buffers, given that this protocol
         specifies contiguous buffers.
+
+        WARNING: the ``nan_as_null`` parameter will be removed from the API protocol.
+        Please avoid passing it as either a positional or keyword argument. Call this
+        method using ``.__dataframe__(allow_copy=...)``.
         """
         pass
 


### PR DESCRIPTION
As discussed in #226

This PR adds a warning to the `nan_as_null` parameter.