### PR TITLE
Add DataFrame.insert_columns

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -219,7 +219,8 @@ class DataFrame:
         Parameters
         ----------
         columns : Column | Sequence[Column]
-            Column(s) to insert. Insertion order is not guaranteed.
+            Column(s) to insert. These will appear at the rightmost location, but
+            insertion order is not guaranteed.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -209,6 +209,52 @@ class DataFrame:
         """
         ...
 
+    def insert_columns(self, columns: Sequence[Column[Any]]) -> DataFrame:
+        """
+        Insert columns into DataFrame at rightmost location.
+
+        Like :meth:`insert_column`, but can insert multiple (independent) columns.
+        Some implementations may be able to make use of parallelism in this
+        case. For example instead of:
+        
+        .. code-block::
+
+            new_column = df.get_column_by_name('a') + 1
+            df = df.insert_column(new_column.rename('a_plus_1'))
+            new_column = df.get_column_by_name('b') + 1
+            df = df.insert_column(new_column.rename('b_plus_1'))
+        
+        it would be better to write
+
+        .. code-block::
+
+            new_column_0 = df.get_column_by_name('a') + 1
+            new_column_1 = df.get_column_by_name('b') + 1
+            df = df.insert_columns(
+                [
+                    new_column_0.rename('a_plus_1'),
+                    new_column_1.rename('b_plus_1'),
+                ]
+            )
+        
+        so that insertion can happen in parallel for some implementations.
+
+        Parameters
+        ----------
+        columns : Sequence[Column]
+            Sequence of `Column`s.
+            Must be independent of each other.
+            Column names must be unique.
+            Column names may not already be present in the
+            dataframe - use :meth:`Column.rename` to rename them
+            beforehand if necessary.
+        
+        Returns
+        -------
+        DataFrame
+        """
+        ...
+
     def drop_column(self, label: str) -> DataFrame:
         """
         Drop the specified column.

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -206,7 +206,7 @@ class DataFrame:
         If inserting multiple columns, they must be indepedent.
         For example, instead of
         
-        .. code-block::
+        .. code-block::python
 
             new_column = df.get_column_by_name('a') + 1
             df = df.insert_column(new_column.rename('a_plus_1'))
@@ -215,7 +215,7 @@ class DataFrame:
         
         it would be better to write
 
-        .. code-block::
+        .. code-block::python
 
             new_column_0 = df.get_column_by_name('a') + 1
             new_column_1 = df.get_column_by_name('b') + 1
@@ -233,7 +233,7 @@ class DataFrame:
         columns : Column | Sequence[Column]
             Column(s) to insert. Must be independent of each other. For example,
 
-            .. code-block:: python
+            .. code-block::python
                 new_column_1 = df.get_column_by_name('a').rename('b')
                 new_column_2 = (new_column_1 + 2).rename('c')
                 df.insert_columns([new_column_1, new_column_2])

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -180,9 +180,9 @@ class DataFrame:
         """
         ...
 
-    def insert_column(self, column: Column[Any]) -> DataFrame:
+    def insert_columns(self, columns: Column[Any] | Sequence[Column[Any]]) -> DataFrame:
         """
-        Insert column into DataFrame at rightmost location.
+        Insert column(s) into DataFrame at rightmost location.
 
         The column's name will be used as the label in the resulting dataframe.
         To insert the column with a different name, combine with `Column.rename`,
@@ -203,19 +203,8 @@ class DataFrame:
             df = df.insert_column(new_column.rename('a_plus_1'))
             df = df.get_columns_by_name(new_column_names)
 
-        Parameters
-        ----------
-        column : Column
-        """
-        ...
-
-    def insert_columns(self, columns: Sequence[Column[Any]]) -> DataFrame:
-        """
-        Insert columns into DataFrame at rightmost location.
-
-        Like :meth:`insert_column`, but can insert multiple (independent) columns.
-        Some implementations may be able to make use of parallelism in this
-        case. For example instead of:
+        If inserting multiple columns, they must be indepedent.
+        For example, instead of
         
         .. code-block::
 
@@ -241,17 +230,15 @@ class DataFrame:
 
         Parameters
         ----------
-        columns : Sequence[Column]
-            Sequence of `Column`s.
-            Must be independent of each other.
-            Column names must be unique.
-            Column names may not already be present in the
-            dataframe - use :meth:`Column.rename` to rename them
-            beforehand if necessary.
-        
-        Returns
-        -------
-        DataFrame
+        columns : Column | Sequence[Column]
+            Column(s) to insert. Must be independent of each other. For example,
+
+            .. code-block:: python
+                new_column_1 = df.get_column_by_name('a').rename('b')
+                new_column_2 = (new_column_1 + 2).rename('c')
+                df.insert_columns([new_column_1, new_column_2])
+            
+            is not allowed, as `new_column_2` depends on `new_column_1`.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -203,8 +203,9 @@ class DataFrame:
             df = df.insert_column(new_column.rename('a_plus_1'))
             df = df.get_columns_by_name(new_column_names)
 
-        If inserting multiple columns, they must be indepedent.
-        For example, 
+        If inserting multiple columns, then the order in which they are inserted
+        is not guaranteed and may vary across implementations. For example, the
+        following
 
         .. code-block:: python
 
@@ -212,13 +213,13 @@ class DataFrame:
             new_column_2 = (new_column_1 + 2).rename('c')
             df.insert_columns([new_column_1, new_column_2])
             
-        is not allowed, as `new_column_2` depends on `new_column_1`.
+        is not supported, as `new_column_2` is derived from `new_column_1`, which may
+        not be part of the dataframe if `new_column_2` is inserted first.
 
         Parameters
         ----------
         columns : Column | Sequence[Column]
-            Column(s) to insert. Must be independent of each other, so that insertion
-            can happen in parallel in some implementations.
+            Column(s) to insert. Insertion order is not guaranteed.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -204,41 +204,21 @@ class DataFrame:
             df = df.get_columns_by_name(new_column_names)
 
         If inserting multiple columns, they must be indepedent.
-        For example, instead of
-        
-        .. code-block::python
+        For example, 
 
-            new_column = df.get_column_by_name('a') + 1
-            df = df.insert_column(new_column.rename('a_plus_1'))
-            new_column = df.get_column_by_name('b') + 1
-            df = df.insert_column(new_column.rename('b_plus_1'))
-        
-        it would be better to write
+        .. code-block:: python
 
-        .. code-block::python
-
-            new_column_0 = df.get_column_by_name('a') + 1
-            new_column_1 = df.get_column_by_name('b') + 1
-            df = df.insert_columns(
-                [
-                    new_column_0.rename('a_plus_1'),
-                    new_column_1.rename('b_plus_1'),
-                ]
-            )
-        
-        so that insertion can happen in parallel for some implementations.
+            new_column_1 = df.get_column_by_name('a').rename('b')
+            new_column_2 = (new_column_1 + 2).rename('c')
+            df.insert_columns([new_column_1, new_column_2])
+            
+        is not allowed, as `new_column_2` depends on `new_column_1`.
 
         Parameters
         ----------
         columns : Column | Sequence[Column]
-            Column(s) to insert. Must be independent of each other. For example,
-
-            .. code-block::python
-                new_column_1 = df.get_column_by_name('a').rename('b')
-                new_column_2 = (new_column_1 + 2).rename('c')
-                df.insert_columns([new_column_1, new_column_2])
-            
-            is not allowed, as `new_column_2` depends on `new_column_1`.
+            Column(s) to insert. Must be independent of each other, so that insertion
+            can happen in parallel in some implementations.
         """
         ...
 


### PR DESCRIPTION
Example from polars of where this makes a difference:

Inserting sequentially:
```python
In [19]: df = pl.LazyFrame({"a": [1, 1, 2], 'b': [4,5,6]})

In [20]: df = df.with_columns(a_plus_one=pl.col('a')+1)

In [21]: df = df.with_columns(b_plus_one=pl.col('b')+1)

In [22]: print(df.explain())
 WITH_COLUMNS:
 [[(col("b")) + (1)].alias("b_plus_one")]
   WITH_COLUMNS:
   [[(col("a")) + (1)].alias("a_plus_one")]
    DF ["a", "b"]; PROJECT */2 COLUMNS; SELECTION: "None"
```

Inserting in parallel, as `a_plus_1` and `b_plus_1` are independent:
```python
In [25]: df = pl.LazyFrame({"a": [1, 1, 2], 'b': [4,5,6]})

In [26]: df = df.with_columns(
    ...:     a_plus_one=pl.col('a')+1,
    ...:     b_plus_one=pl.col('b')+1,
    ...: )

In [27]: print(df.explain())
 WITH_COLUMNS:
 [[(col("a")) + (1)].alias("a_plus_one"), [(col("b")) + (1)].alias("b_plus_one")]
  DF ["a", "b"]; PROJECT */2 COLUMNS; SELECTION: "None"
```