### PR TITLE
Add DataFrame.sort and Column.sort

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -141,6 +141,35 @@ class Column(Generic[DType]):
         """
         ...
 
+    def sort(
+        self,
+        *,
+        ascending: bool = True,
+        nulls_position: Literal['first', 'last'] = 'last',
+    ) -> Column[DType]:
+        """
+        Sort column.
+
+        If you need the indices which would sort the column,
+        use :meth:`sorted_indices`.
+
+        Parameters
+        ----------
+        ascending : bool
+            If `True`, sort in ascending order.
+            If `False`, sort in descending order.
+        nulls_position : ``{'first', 'last'}``
+            Whether null values should be placed at the beginning
+            or at the end of the result.
+            Note that the position of NaNs is unspecified and may
+            vary based on the implementation.
+
+        Returns
+        -------
+        Column
+        """
+        ...
+
     def sorted_indices(
         self,
         *,

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -179,9 +179,7 @@ class Column(Generic[DType]):
         """
         Return row numbers which would sort column.
 
-        If you need to sort the Column, you can simply do::
-
-            col.get_rows(col.sorted_indices())
+        If you need to sort the Column, use :meth:`sort`.
 
         Parameters
         ----------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -244,6 +244,47 @@ class DataFrame:
         Sequence[str]
         """
         ...
+    
+    def sort(
+        self,
+        keys: Sequence[str] | None = None,
+        *,
+        ascending: Sequence[bool] | bool = True,
+        nulls_position: Literal['first', 'last'] = 'last',
+    ) -> DataFrame:
+        """
+        Sort dataframe according to given columns.
+
+        If you only need the indices which would sort the dataframe, use
+        :meth:`sorted_indices`.
+
+        Parameters
+        ----------
+        keys : Sequence[str] | None
+            Names of columns to sort by.
+            If `None`, sort by all columns.
+        ascending : Sequence[bool] or bool
+            If `True`, sort by all keys in ascending order.
+            If `False`, sort by all keys in descending order.
+            If a sequence, it must be the same length as `keys`,
+            and determines the direction with which to use each
+            key to sort by.
+        nulls_position : ``{'first', 'last'}``
+            Whether null values should be placed at the beginning
+            or at the end of the result.
+            Note that the position of NaNs is unspecified and may
+            vary based on the implementation.
+
+        Returns
+        -------
+        DataFrame
+    
+        Raises
+        ------
+        ValueError
+            If `keys` and `ascending` are sequences of different lengths.
+        """
+        ...
 
     def sorted_indices(
         self,

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -296,9 +296,7 @@ class DataFrame:
         """
         Return row numbers which would sort according to given columns.
 
-        If you need to sort the DataFrame, you can simply do::
-
-            df.get_rows(df.sorted_indices(keys))
+        If you need to sort the DataFrame, use :meth:`sort`.
 
         Parameters
         ----------


### PR DESCRIPTION
Feedback I received when showing this to people is that

```python
col.get_rows(col.sorted_indices())
```
isn't ergonomic

It's also a performance footgun
```python
In [1]: df = pl.DataFrame({'a': np.random.randint(0, 4, size=100_000_000)})

In [2]: %timeit df[df['a'].arg_sort()]
2.56 s ± 80.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: %timeit df.sort('a')
700 ms ± 21.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```