### PR TITLE
Prefer `str | list[str]` over `Sequence[str]`

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -65,13 +65,13 @@ class DataFrame:
         Return number of rows and number of columns.
         """
 
-    def groupby(self, keys: Sequence[str], /) -> GroupBy:
+    def groupby(self, keys: str | list[str], /) -> GroupBy:
         """
         Group the DataFrame by the given columns.
 
         Parameters
         ----------
-        keys : Sequence[str]
+        keys : str | list[str]
 
         Returns
         -------
@@ -247,7 +247,7 @@ class DataFrame:
     
     def sort(
         self,
-        keys: Sequence[str] | None = None,
+        keys: str | list[str] | None = None,
         *,
         ascending: Sequence[bool] | bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
@@ -260,7 +260,7 @@ class DataFrame:
 
         Parameters
         ----------
-        keys : Sequence[str] | None
+        keys : str | list[str], optional
             Names of columns to sort by.
             If `None`, sort by all columns.
         ascending : Sequence[bool] or bool
@@ -288,7 +288,7 @@ class DataFrame:
 
     def sorted_indices(
         self,
-        keys: Sequence[str] | None = None,
+        keys: str | list[str] | None = None,
         *,
         ascending: Sequence[bool] | bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
@@ -300,7 +300,7 @@ class DataFrame:
 
         Parameters
         ----------
-        keys : Sequence[str] | None
+        keys : str | list[str], optional
             Names of columns to sort by.
             If `None`, sort by all columns.
         ascending : Sequence[bool] or bool
@@ -793,9 +793,15 @@ class DataFrame:
         """
         ...
 
-    def unique_indices(self, keys: Sequence[str], *, skip_nulls: bool = True) -> Column[int]:
+    def unique_indices(self, keys: str | list[str] | None = None, *, skip_nulls: bool = True) -> Column[int]:
         """
         Return indices corresponding to unique values across selected columns.
+
+        Parameters
+        ----------
+        keys : str | list[str], optional
+            Column names to consider when finding unique values.
+            If `None`, all columns are considered.
 
         Returns
         -------


### PR DESCRIPTION
see https://github.com/data-apis/dataframe-api/issues/212

This would make it clearer that you can either pass a single column name, or a list of column names.

`Sequence[str]` would accept `'abcd'` but it's ambiguous whether that means "column 'abcd'" or "columns 'a', 'b', 'c', 'd'", given that `str` is itself a `Sequence[str]` 