### PR TITLE
Remove cross-dataframe comparisons

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -326,7 +326,7 @@ class DataFrame:
         """
         ...
 
-    def __eq__(self, other: DataFrame | Scalar) -> DataFrame:  # type: ignore[override]
+    def __eq__(self, other: Scalar) -> DataFrame:  # type: ignore[override]
         """
         Compare for equality.
 
@@ -334,8 +334,7 @@ class DataFrame:
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -345,7 +344,7 @@ class DataFrame:
         """
         ...
 
-    def __ne__(self, other: DataFrame | Scalar) -> DataFrame:  # type: ignore[override]
+    def __ne__(self, other: Scalar) -> DataFrame:  # type: ignore[override]
         """
         Compare for non-equality.
 
@@ -353,8 +352,7 @@ class DataFrame:
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -364,14 +362,13 @@ class DataFrame:
         """
         ...
 
-    def __ge__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __ge__(self, other: Scalar) -> DataFrame:
         """
         Compare for "greater than or equal to" `other`.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -381,14 +378,13 @@ class DataFrame:
         """
         ...
 
-    def __gt__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __gt__(self, other: Scalar) -> DataFrame:
         """
         Compare for "greater than" `other`.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -398,14 +394,13 @@ class DataFrame:
         """
         ...
 
-    def __le__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __le__(self, other: Scalar) -> DataFrame:
         """
         Compare for "less than or equal to" `other`.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -415,14 +410,13 @@ class DataFrame:
         """
         ...
 
-    def __lt__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __lt__(self, other: Scalar) -> DataFrame:
         """
         Compare for "less than" `other`.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -432,16 +426,15 @@ class DataFrame:
         """
         ...
 
-    def __and__(self, other: DataFrame | bool) -> DataFrame:
+    def __and__(self, other: bool) -> DataFrame:
         """
-        Apply logical 'and' to `other` DataFrame (or scalar) and this dataframe.
+        Apply logical 'and' to `other` scalar and this dataframe.
 
         Nulls should follow Kleene Logic.
 
         Parameters
         ----------
-        other : DataFrame[bool] or bool
-            If DataFrame, must have same length.
+        other : bool
 
         Returns
         -------
@@ -455,14 +448,13 @@ class DataFrame:
 
     def __or__(self, other: DataFrame | bool) -> DataFrame:
         """
-        Apply logical 'or' to `other` DataFrame (or scalar) and this DataFrame.
+        Apply logical 'or' to `other` scalar and this DataFrame.
 
         Nulls should follow Kleene Logic.
 
         Parameters
         ----------
-        other : DataFrame[bool] or bool
-            If DataFrame, must have same length.
+        other : bool
 
         Returns
         -------
@@ -474,14 +466,13 @@ class DataFrame:
             If `self` or `other` is not boolean.
         """
 
-    def __add__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __add__(self, other: Scalar) -> DataFrame:
         """
-        Add `other` dataframe or scalar to this dataframe.
+        Add `other` scalar to this dataframe.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -491,14 +482,13 @@ class DataFrame:
         """
         ...
 
-    def __sub__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __sub__(self, other: Scalar) -> DataFrame:
         """
-        Subtract `other` dataframe or scalar from this dataframe.
+        Subtract `other` scalar from this dataframe.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -508,14 +498,13 @@ class DataFrame:
         """
         ...
 
-    def __mul__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __mul__(self, other: Scalar) -> DataFrame:
         """
-        Multiply  `other` dataframe or scalar with this dataframe.
+        Multiply  `other` scalar with this dataframe.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -525,14 +514,13 @@ class DataFrame:
         """
         ...
 
-    def __truediv__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __truediv__(self, other: Scalar) -> DataFrame:
         """
-        Divide  this dataframe by `other` dataframe or scalar. True division, returns floats.
+        Divide  this dataframe by `other` scalar. True division, returns floats.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -542,14 +530,13 @@ class DataFrame:
         """
         ...
 
-    def __floordiv__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __floordiv__(self, other: Scalar) -> DataFrame:
         """
-        Floor-divide (returns integers) this dataframe by `other` dataframe or scalar.
+        Floor-divide (returns integers) this dataframe by `other` scalar.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -559,7 +546,7 @@ class DataFrame:
         """
         ...
 
-    def __pow__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __pow__(self, other: Scalar) -> DataFrame:
         """
         Raise this dataframe to the power of `other`.
 
@@ -569,8 +556,7 @@ class DataFrame:
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -580,14 +566,13 @@ class DataFrame:
         """
         ...
 
-    def __mod__(self, other: DataFrame | Scalar) -> DataFrame:
+    def __mod__(self, other: Scalar) -> DataFrame:
         """
         Return modulus of this dataframe by `other` (`%` operator).
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
@@ -597,20 +582,19 @@ class DataFrame:
         """
         ...
 
-    def __divmod__(self, other: DataFrame | Scalar) -> tuple[DataFrame, DataFrame]:
+    def __divmod__(self, other: Scalar) -> tuple[DataFrame, DataFrame]:
         """
         Return quotient and remainder of integer division. See `divmod` builtin function.
 
         Parameters
         ----------
-        other : DataFrame or Scalar
-            If DataFrame, must have same length and matching columns.
+        other : Scalar
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
 
         Returns
         -------
-        A tuple of two DataFrame's
+        A tuple of two `DataFrame`s
         """
         ...
 


### PR DESCRIPTION
Just out of interest, has any here ever needed to sum two entire dataframes? I haven't, and don't think there's much use for these comparison ops when `other` is a dataframe

It also avoids some of the discussion in #224 - if it can't be done, there's no need to document that in some cases it might not be allowed