### PR TITLE
rename `get_columns_by_name` to `select`

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -109,7 +109,7 @@ class DataFrame:
         """
         ...
 
-    def get_columns_by_name(self, names: Sequence[str], /) -> DataFrame:
+    def select(self, names: Sequence[str], /) -> DataFrame:
         """
         Select multiple columns by name.
 
@@ -194,14 +194,14 @@ class DataFrame:
             df = df.insert_column(new_column.rename('a_plus_1'))
         
         If you need to insert the column at a different location, combine with
-        :meth:`get_columns_by_name`, e.g.:
+        :meth:`select`, e.g.:
 
         .. code-block:: python
 
             new_column = df.get_column_by_name('a') + 1
             new_columns_names = ['a_plus_1'] + df.get_column_names()
             df = df.insert_column(new_column.rename('a_plus_1'))
-            df = df.get_columns_by_name(new_column_names)
+            df = df.select(new_column_names)
 
         Parameters
         ----------


### PR DESCRIPTION
"get_columns_by_name" has been annoying me for a while. Someone has even commented that there's no need to note that this API is developer-focused, as with such an anti-ergonomic name, no user would ever consider using it anyway 😄 
Then, the following question from a user has prompted me to finally suggest renaming it:

![image](https://github.com/data-apis/dataframe-api/assets/33491632/9562f275-9354-4dd2-8e1e-8f9bc98ca1e8)

I'm suggesting `select` because it's already the standardised name:
- in SQL, you select columns with `select`
- pyspark has `DataFrame.select`
- polars has `DataFrame.select`