### PR TITLE
Rename `get_rows_by_mask` to `filter`

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -104,7 +104,7 @@ class Column(Generic[DType]):
         ...
 
 
-    def get_rows_by_mask(self: Column[DType], mask: Column[Bool]) -> Column[DType]:
+    def filter(self: Column[DType], mask: Column[Bool]) -> Column[DType]:
         """
         Select a subset of rows corresponding to a mask.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -161,7 +161,7 @@ class DataFrame:
         """
         ...
 
-    def get_rows_by_mask(self, mask: Column[Bool]) -> DataFrame:
+    def filter(self, mask: Column[Bool]) -> DataFrame:
         """
         Select a subset of rows corresponding to a mask.
 

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -287,7 +287,7 @@ def my_dataframe_agnostic_function(df):
     df = df.__dataframe_consortium_standard__(api_version='2023.08-beta')
 
     mask = df.get_column_by_name('species') != 'setosa'
-    df = df.get_rows_by_mask(mask)
+    df = df.filter(mask)
 
     for column_name in df.get_column_names():
         if column_name == 'species':


### PR DESCRIPTION
Similar to #245

In for a penny, in for a pound - if we're gonna make breaking changes whilst we're still in "beta", I suggest we go all the way there

Areg had said that it would be nice to get to the point of making this user-friendly, and names like `get_columns_by_name` and `get_rows_by_mask` aren't really going to cut it

why `filter`? Because it's already there in:
- pyspark
- polars