### PR TITLE
RFC Replace column with expression

### DIFF
--- a/spec/API_specification/expression_object.rst
+++ b/spec/API_specification/expression_object.rst
@@ -1,12 +1,12 @@
 .. _column-object:
 
-Column object
-=============
+Expression object
+=================
 
 A conforming implementation of the dataframe API standard must provide and
-support a column object having the following methods, attributes, and
+support an expression object having the following methods, attributes, and
 behavior.
 
 .. currentmodule:: dataframe_api
 
-.. autoclass:: Column
+.. autoclass:: Expression

--- a/spec/API_specification/index.rst
+++ b/spec/API_specification/index.rst
@@ -16,6 +16,11 @@ of objects and functions in the top-level namespace. The latter are:
    __dataframe_api_version__
    is_null
    null
+   col
+   sorted_indices
+   unique_indices
+   any_rowwise
+   all_rowwise
    Int64
    Int32
    Int16
@@ -28,17 +33,14 @@ of objects and functions in the top-level namespace. The latter are:
    Float32
    Bool
    is_dtype
-   column_from_sequence
-   column_from_1d_array
-   dataframe_from_dict
    dataframe_from_2d_array
 
-The ``DataFrame``, ``Column`` and ``GroupBy`` objects have the following
+The ``DataFrame``, ``Expression`` and ``GroupBy`` objects have the following
 methods and attributes:
 
 .. toctree::
    :maxdepth: 3
 
    dataframe_object
-   column_object
+   expression_object
    groupby_object

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -285,16 +285,19 @@ df_polars = pl.scan_parquet('iris.parquet')
 
 def my_dataframe_agnostic_function(df):
     df = df.__dataframe_consortium_standard__(api_version='2023.08-beta')
+    namespace = df.__dataframe_namespace__()
 
-    mask = df.get_column_by_name('species') != 'setosa'
+    mask = namespace.col('species') != 'setosa'
     df = df.get_rows_by_mask(mask)
 
+    new_columns = []
     for column_name in df.get_column_names():
         if column_name == 'species':
             continue
         new_column = df.get_column_by_name(column_name)
         new_column = (new_column - new_column.mean()) / new_column.std()
-        df = df.insert(loc=len(df.get_column_names()), label=f'{column_name}_scaled', value=new_column)
+        new_columns.append(new_columns)
+    df = df.update_columns(new_columns)
 
     return df.dataframe
 


### PR DESCRIPTION
Just demoing what #229 would look like

## Why?

### query engine frontends

The current API makes it look like certain operations are possible. However, for some implementations (e.g. dataframes as frontends to SQL backends, polars lazyframes), the following is currently not possible:
```python
df1: DataFrame
df2: DataFrame
df1.get_rows_by_mask(df1.get_column_by_name('a') > df2.get_column_by_name('b'))
```
because cross-DataFrame comparisons require a join to have been done beforehand.

However, the following is:
```python
df1: DataFrame
df1.get_rows_by_mask(df1.get_column_by_name('a') > df1.get_column_by_name('b'))
```
The API should make it clear what's allowed and what isn't

### Readability

We currently need to write code like
```python
    plant_statistics = plant_statistics.filter(
        (
            plant_statistics.get_column_by_name("sepal_width")
            > plant_statistics.get_column_by_name("sepal_height")
        )
        | (plant_statistics.get_column_by_name("species") == "setosa")
    )
```
which to be honest looks like someone's taken the worst parts of pandas and made them even uglier

## What's the suggestion?

Therefore, to make the API more clearly suggest what is possible, I'm suggesting to add `namespace.col`, which would allow the above to be rewritten as:
```python
df1: DataFrame
df1.filter(col('a') > col('b'))
```

`col('a')` is an Expression. It is a function which maps a DataFrame to a column, and is only evaluated when in the context of a DataFrame method. In the example above, `col('a')` is kind of like `lambda df: df['a']`, and `col('b')` like `lambda df: df['b']`. So, when evaluated within `df1`, they resolve to:
```python
df1.loc[df1['a'] > df1['b']]
```

Expressions can be combined. For example, here is a little demo of standardising each column of the Iris dateset (based on the example I gave at EuroScipy2023):

```python
def my_dataframe_agnostic_function(df):
    df = df.__dataframe_consortium_standard__(api_version="2023.09-beta")
    namespace = df.__dataframe_namespace__()
    col = namespace.col

    mask = col("species") != "setosa"
    df = df.filter(mask)

    updated_columns = []
    for column_name in df.get_column_names():
        if column_name == "species":
            continue
        new_column = col(column_name)
        new_column = (new_column - new_column.mean()) / new_column.std()
        updated_columns.append(new_column)

    df = df.update_columns(*updated_columns)
    return df.dataframe
```

## What would the consequences be?

Every method currently available on `Column`  should be available on `Expression`. The only difference is that `Expression`s are always lazy, and can only be evaluated within DataFrame methods which accept them.

Concretely:

- The following dataframe methods would accept Expressions instead Columns:
  - DataFrame.get_rows_by_mask
  - DataFrame.insert_columns
  - DataFrame.update_columns
  - DataFrame.get_columns_by_name
- The following would become top-level functions which return Expressions, rather than DataFrame functions which return Columns:
  - DataFrame.all_rowwise -> namespace.all_rowwise
  - DataFrame.any_rowwise -> namespace.any_rowwise
  - DataFrame.sorted_indices -> namespace.sorted_indices
  - DataFrame.unique_indices -> namespace.unique_indices
- The following would be removed:
  - namespace.column_from_sequence
  - namespace.column_from_1d_array
  - namespace.dataframe_from_dict
  - DataFrame.get_column_by_name
  - Column
- The following would be added:
  - namespace.col (a function which creates an Expression)
- Every method currently available on `Column`  should be available on `Expression`, except:
  - `dtype`