### PR TITLE
Rename groupby to group_by

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -65,7 +65,7 @@ class DataFrame:
         Return number of rows and number of columns.
         """
 
-    def groupby(self, keys: str | list[str], /) -> GroupBy:
+    def group_by(self, keys: str | list[str], /) -> GroupBy:
         """
         Group the DataFrame by the given columns.
 

--- a/spec/API_specification/dataframe_api/groupby_object.py
+++ b/spec/API_specification/dataframe_api/groupby_object.py
@@ -14,7 +14,7 @@ class GroupBy:
     GroupBy object.
 
     Note that this class is not meant to be constructed by users.
-    It is returned from `DataFrame.groupby`.
+    It is returned from `DataFrame.group_by`.
 
     **Methods**
 


### PR DESCRIPTION
This is what the ecosystem generally does:

- SQL has `GROUP BY`
- pyspark has `groupBy` (note that the `B` is capitalised, as it's the start of a new word)
- dplyr has `group_by`
- polars has `group_by`
- it's two words

I guess the only reason it's currently `groupby` is because that's what pandas did?

But that API is now so far away from pandas anyway, so I suggest we follow the broader ecosystem