### PR TITLE
DOCS fix api version

### DIFF
--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -275,16 +275,18 @@ latest version of the dataframe API specification.  If the given
 version is invalid or not implemented for the given module, an
 error should be raised. Default: ``None``.
 
+Example:
+
 ```python
 import pandas as pd
 import polars as pl
 
 
-df_pandas = pl.read_parquet('iris.parquet')
+df_pandas = pd.read_parquet('iris.parquet')
 df_polars = pl.scan_parquet('iris.parquet')
 
 def my_dataframe_agnostic_function(df):
-    df = df.__dataframe_consortium_standard__(api_version='2023.08-beta')
+    df = df.__dataframe_consortium_standard__(api_version='2023.09-beta')
 
     mask = df.get_column_by_name('species') != 'setosa'
     df = df.filter(mask)
@@ -294,7 +296,7 @@ def my_dataframe_agnostic_function(df):
             continue
         new_column = df.get_column_by_name(column_name)
         new_column = (new_column - new_column.mean()) / new_column.std()
-        df = df.insert(loc=len(df.get_column_names()), label=f'{column_name}_scaled', value=new_column)
+        df = df.insert_column(new_column.rename(f'{column_name}_scaled'))
 
     return df.dataframe
 
@@ -303,8 +305,6 @@ my_dataframe_agnostic_function(df_pandas)
 my_dataframe_agnostic_function(df_polars)
 my_dataframe_agnostic_function(df_any_other_library_with_a_standard_compliant_namespace)
 ```
-
-Example:
 
 ### Checking a dataframe object for Compliance
 


### PR DESCRIPTION
the current example shows new syntax but an old api version

going to self-merge as this is super-minor (and people aren't around anyway)