### PR TITLE
update/insert columns -> assign

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -180,53 +180,27 @@ class DataFrame:
         """
         ...
 
-    def insert_column(self, column: Column[Any]) -> DataFrame:
+    def with_columns(self, columns: Column[Any] | Sequence[Column[Any]], /) -> DataFrame:
         """
-        Insert column into DataFrame at rightmost location.
+        Insert new column(s), or update values in existing ones.
 
-        The column's name will be used as the label in the resulting dataframe.
-        To insert the column with a different name, combine with `Column.rename`,
-        e.g.:
+        If inserting new columns, the column's names will be used as the labels,
+        and the columns will be inserted at the rightmost location.
+
+        If updating existing columns, their names will be used to tell which columns
+        to update. To update a column with a different name, combine with
+        :meth:`Column.rename`, e.g.:
 
         .. code-block:: python
 
             new_column = df.get_column_by_name('a') + 1
-            df = df.insert_column(new_column.rename('a_plus_1'))
-        
-        If you need to insert the column at a different location, combine with
-        :meth:`select`, e.g.:
-
-        .. code-block:: python
-
-            new_column = df.get_column_by_name('a') + 1
-            new_columns_names = ['a_plus_1'] + df.column_names
-            df = df.insert_column(new_column.rename('a_plus_1'))
-            df = df.select(new_column_names)
-
-        Parameters
-        ----------
-        column : Column
-        """
-        ...
-
-    def update_columns(self, columns: Column[Any] | Sequence[Column[Any]], /) -> DataFrame:
-        """
-        Update values in existing column(s) from Dataframe.
-
-        The column's name will be used to tell which column to update.
-        To update a column with a different name, combine with :meth:`Column.rename`,
-        e.g.:
-
-        .. code-block:: python
-
-            new_column = df.get_column_by_name('a') + 1
-            df = df.update_column(new_column.rename('b'))
+            df = df.with_columns(new_column.rename('b'))
 
         Parameters
         ----------
         columns : Column | Sequence[Column]
-            Column(s) to update. If updating multiple columns, they must all have
-            different names.
+            Column(s) to update/insert. If updating/inserting multiple columns,
+            they must all have different names.
 
         Returns
         -------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -180,7 +180,7 @@ class DataFrame:
         """
         ...
 
-    def with_columns(self, columns: Column[Any] | Sequence[Column[Any]], /) -> DataFrame:
+    def assign(self, columns: Column[Any] | Sequence[Column[Any]], /) -> DataFrame:
         """
         Insert new column(s), or update values in existing ones.
 
@@ -194,7 +194,7 @@ class DataFrame:
         .. code-block:: python
 
             new_column = df.get_column_by_name('a') + 1
-            df = df.with_columns(new_column.rename('b'))
+            df = df.assign(new_column.rename('b'))
 
         Parameters
         ----------

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -296,7 +296,7 @@ def my_dataframe_agnostic_function(df):
             continue
         new_column = df.get_column_by_name(column_name)
         new_column = (new_column - new_column.mean()) / new_column.std()
-        df = df.insert_column(new_column.rename(f'{column_name}_scaled'))
+        df = df.with_columns(new_column.rename(f'{column_name}_scaled'))
 
     return df.dataframe
 

--- a/spec/purpose_and_scope.md
+++ b/spec/purpose_and_scope.md
@@ -296,7 +296,7 @@ def my_dataframe_agnostic_function(df):
             continue
         new_column = df.get_column_by_name(column_name)
         new_column = (new_column - new_column.mean()) / new_column.std()
-        df = df.with_columns(new_column.rename(f'{column_name}_scaled'))
+        df = df.assign(new_column.rename(f'{column_name}_scaled'))
 
     return df.dataframe
 


### PR DESCRIPTION
closes #235 

I think I made a mistake in splitting "set_column" into "insert_column" and "update_column":
1. first, because having tried using the Standard to write code a while now, it's really tedious to have to distinguish them
2. because I don't think any existing dataframe library has this distinction
3. a users has brought this up too (#235)

In keeping with the goal of making the standard feel familiar, let's look at what existing dataframe libraries do:
- pandas and its clones: either `__setitem__` (which the consortium doesn't want) or `DataFrame.assign`
- pyspark / polars: `DataFrame.with_columns`
- ibis: `DataFrame.mutate`
- datatable: `update / extend`
 
I don't really mind which one we go with. I'm suggesting `with_columns` here as I think it's probably the most explicit