### PR TITLE
[Protocol] Make Column.get_buffers() docstring more explicit

### DIFF
--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -345,6 +345,12 @@ class Column(ABC):
         """
         Return a dictionary containing the underlying buffers.
 
+        Each buffer has its own dtype which can be distinct from the
+        column's dtype. For example, a column with the ``STRING`` dtype
+        could be represented by two buffers: a "data" buffer with
+        dtype ``INT`` and bit width 8, and an "offsets" buffer with
+        dtype ``INT`` and bit width 32.
+
         The returned dictionary has the following contents:
 
             - "data": a two-element tuple whose first element is a buffer


### PR DESCRIPTION
Several implementations got ``Column.get_buffers()`` wrong by assuming the buffers dtypes would be the same as the column dtype. Clarify to eliminate any ambiguity.

See https://github.com/apache/arrow/issues/37598 for example.