### PR TITLE
Replace dataframe_from_dict with dataframe_from_columns

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "column_from_sequence",
     "column_from_1d_array",
     "concat",
-    "dataframe_from_dict",
+    "dataframe_from_columns",
     "dataframe_from_2d_array",
     "is_null",
     "null",
@@ -91,27 +91,20 @@ def column_from_sequence(sequence: Sequence[Any], *, dtype: DType, name: str = '
     """
     ...
 
-def dataframe_from_dict(data: Mapping[str, Column]) -> DataFrame:
+def dataframe_from_columns(*columns: Column) -> DataFrame:
     """
-    Construct DataFrame from map of column names to Columns.
+    Construct DataFrame from sequence of Columns.
 
     Parameters
     ----------
-    data : Mapping[str, Column]
-        Column must be of the corresponding type of the DataFrame.
+    columns : Column
+        Column(s) must be of the corresponding type of the DataFrame.
         For example, it is only supported to build a ``LibraryXDataFrame`` using
         ``LibraryXColumn`` instances.
 
     Returns
     -------
     DataFrame
-    
-    Raises
-    ------
-    ValueError
-        If any of the columns already has a name, and the corresponding key
-        in `data` doesn't match.
-
     """
     ...
 

--- a/spec/API_specification/dataframe_api/_types.py
+++ b/spec/API_specification/dataframe_api/_types.py
@@ -125,19 +125,16 @@ class Namespace(Protocol):
         *,
         dtype: Any,
         name: str = "",
-        api_version: str | None = None,
     ) -> ColumnType:
         ...
 
     @staticmethod
-    def dataframe_from_dict(
-        data: Mapping[str, ColumnType], *, api_version: str | None = None
-    ) -> DataFrameType:
+    def dataframe_from_columns(*columns: ColumnType) -> DataFrameType:
         ...
 
     @staticmethod
     def column_from_1d_array(
-        array: Any, *, dtype: Any, name: str = "", api_version: str | None = None
+        array: Any, *, dtype: Any, name: str = ""
     ) -> ColumnType:
         ...
 
@@ -147,7 +144,6 @@ class Namespace(Protocol):
         *,
         names: Sequence[str],
         dtypes: Mapping[str, Any],
-        api_version: str | None = None,
     ) -> DataFrameType:
         ...
 

--- a/spec/API_specification/examples/02_plotting.py
+++ b/spec/API_specification/examples/02_plotting.py
@@ -15,7 +15,9 @@ def group_by_and_plot(
 
     namespace = x.__column_namespace__()
 
-    df = namespace.dataframe_from_dict({"x": x, "y": y, "color": color})
+    df = namespace.dataframe_from_columns(
+        x.rename('x'), y.rename('y'), color.rename('color')
+    )
 
     agg = df.group_by("color").mean()
     x = agg.get_column_by_name("x").to_array_object(namespace.Float64())

--- a/spec/API_specification/index.rst
+++ b/spec/API_specification/index.rst
@@ -34,7 +34,7 @@ of objects and functions in the top-level namespace. The latter are:
    is_dtype
    column_from_sequence
    column_from_1d_array
-   dataframe_from_dict
+   dataframe_from_columns
    dataframe_from_2d_array
 
 The ``DataFrame``, ``Column`` and ``GroupBy`` objects have the following


### PR DESCRIPTION
`Column`s have names, so `dataframe_from_dict` isn't really necessary

drive-by: removing `api_version` from the functions in the `Namespace` protocol, which I should've done in https://github.com/data-apis/dataframe-api/pull/264