### PR TITLE
Make dataframe-api installable

### DIFF
--- a/spec/API_specification/pyproject.toml
+++ b/spec/API_specification/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "dataframe_api"
+version = "2023.10-beta"
+description = "Dataframe API specification"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/data-apis/dataframe-api"
+"Bug Tracker" = "https://github.com/data-apis/dataframe-api"


### PR DESCRIPTION
Can we make the dataframe-api installable please? This would make development of the implementation much more pleasant