### PR TITLE
Allow for positional arguments instead of str | list[str]

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -794,7 +794,7 @@ class DataFrame:
         """
         ...
 
-    def unique_indices(self, *keys: str, *, skip_nulls: bool = True) -> Column:
+    def unique_indices(self, *keys: str, skip_nulls: bool = True) -> Column:
         """
         Return indices corresponding to unique values across selected columns.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -64,13 +64,13 @@ class DataFrame:
         Return number of rows and number of columns.
         """
 
-    def group_by(self, keys: str | list[str], /) -> GroupBy:
+    def group_by(self, *keys: str) -> GroupBy:
         """
         Group the DataFrame by the given columns.
 
         Parameters
         ----------
-        keys : str | list[str]
+        *keys : str
 
         Returns
         -------
@@ -179,7 +179,7 @@ class DataFrame:
         """
         ...
 
-    def assign(self, columns: Column | Sequence[Column], /) -> DataFrame:
+    def assign(self, *columns: Column) -> DataFrame:
         """
         Insert new column(s), or update values in existing ones.
 
@@ -197,7 +197,7 @@ class DataFrame:
 
         Parameters
         ----------
-        columns : Column | Sequence[Column]
+        *columns : Column
             Column(s) to update/insert. If updating/inserting multiple columns,
             they must all have different names.
 
@@ -207,13 +207,13 @@ class DataFrame:
         """
         ...
 
-    def drop_columns(self, label: str | list[str]) -> DataFrame:
+    def drop_columns(self, *labels: str) -> DataFrame:
         """
         Drop the specified column(s).
 
         Parameters
         ----------
-        label : str | list[str]
+        *label : str
             Column name(s) to drop.
 
         Returns
@@ -266,8 +266,7 @@ class DataFrame:
     
     def sort(
         self,
-        keys: str | list[str] | None = None,
-        *,
+        *keys: str,
         ascending: Sequence[bool] | bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
     ) -> DataFrame:
@@ -279,9 +278,9 @@ class DataFrame:
 
         Parameters
         ----------
-        keys : str | list[str], optional
+        *keys : str
             Names of columns to sort by.
-            If `None`, sort by all columns.
+            If not specified, sort by all columns.
         ascending : Sequence[bool] or bool
             If `True`, sort by all keys in ascending order.
             If `False`, sort by all keys in descending order.
@@ -307,8 +306,7 @@ class DataFrame:
 
     def sorted_indices(
         self,
-        keys: str | list[str] | None = None,
-        *,
+        *keys: str,
         ascending: Sequence[bool] | bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
     ) -> Column:
@@ -319,9 +317,9 @@ class DataFrame:
 
         Parameters
         ----------
-        keys : str | list[str], optional
+        *keys : str
             Names of columns to sort by.
-            If `None`, sort by all columns.
+            If not specified, sort by all columns.
         ascending : Sequence[bool] or bool
             If `True`, sort by all keys in ascending order.
             If `False`, sort by all keys in descending order.
@@ -796,15 +794,15 @@ class DataFrame:
         """
         ...
 
-    def unique_indices(self, keys: str | list[str] | None = None, *, skip_nulls: bool = True) -> Column:
+    def unique_indices(self, *keys: str, *, skip_nulls: bool = True) -> Column:
         """
         Return indices corresponding to unique values across selected columns.
 
         Parameters
         ----------
-        keys : str | list[str], optional
+        *keys : str
             Column names to consider when finding unique values.
-            If `None`, all columns are considered.
+            If not specified, all columns are considered.
 
         Returns
         -------


### PR DESCRIPTION
I'd like to suggest passing multiple columns positionally, rather than as `str | list[str]`.

First, this is more ergonomic to write, as it saves an extra pair of brackets (and an extra level
of indentation...).

Second, because this is actually already supported in both pandas and Polars:
```python
# pandas

In [2]: df.assign(
   ...:     d=lambda x: x['a']*2,
   ...:     e=lambda x: x['b'] - x['a']
   ...: )
Out[2]:
   a  b  c  d  e
0  1  4  4  2  3
1  2  5  2  4  3
2  3  6  1  6  3

# Polars

In [1]: df.with_columns(
   ...:     d=pl.col('a')*2,
   ...:     e=pl.col('b')-pl.col('a')
   ...: )
Out[1]:
shape: (3, 5)
┌─────┬─────┬─────┬─────┬─────┐
│ a   ┆ b   ┆ c   ┆ d   ┆ e   │
│ --- ┆ --- ┆ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╪═════╪═════╡
│ 1   ┆ 4   ┆ 4   ┆ 2   ┆ 3   │
│ 2   ┆ 5   ┆ 2   ┆ 4   ┆ 3   │
│ 3   ┆ 6   ┆ 1   ┆ 6   ┆ 3   │
└─────┴─────┴─────┴─────┴─────┘
```

Third, because it doesn't restrict multiple arguments to being `list` - now, as long as they're an iterable,
they can be passed.

(Reminder: the reason we can't have `str | Iterable[str]` is that in Python `str` is itself an `Iterable[str]`,
so it's ambiguous whether `columns='abc'` means "just column 'abc'" or "columns 'a', 'b', and 'c'".)