### PR TITLE
type DataFrame, Column, and GroupBy as Protocol

### DIFF
--- a/spec/API_specification/.mypy.ini
+++ b/spec/API_specification/.mypy.ini
@@ -1,5 +1,2 @@
 [mypy]
 strict=True
-
-[mypy-dataframe_api.*]
-disable_error_code=empty-body

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="empty-body"
 """
 Function stubs and API documentation for the DataFrame API standard.
 """

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any,NoReturn, TYPE_CHECKING, Literal, Generic
+from typing import Any,NoReturn, TYPE_CHECKING, Literal, Protocol
 
 if TYPE_CHECKING:
     from .typing import NullType, Scalar, DType, Namespace
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 __all__ = ['Column']
 
 
-class Column:
+class Column(Protocol):
     """
     Column object
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Mapping, Sequence, Union, TYPE_CHECKING, NoReturn
+from typing import Any, Literal, Mapping, Sequence, TYPE_CHECKING, NoReturn, Protocol
 
 
 if TYPE_CHECKING:
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 __all__ = ["DataFrame"]
 
 
-class DataFrame:
+class DataFrame(Protocol):
     """
     DataFrame object
 

--- a/spec/API_specification/dataframe_api/groupby_object.py
+++ b/spec/API_specification/dataframe_api/groupby_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from .dataframe_object import DataFrame
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 __all__ = ['GroupBy']
 
 
-class GroupBy:
+class GroupBy(Protocol):
     """
     GroupBy object.
 


### PR DESCRIPTION
technically we're defining protocols here - classes which must have certain attributes and methods

might as well type these as Protocol anyway. this will make type checking for implementations simpler, as it tells you whether anything's missing

minimal demo of how this helps:
```console
(.venv) marcogorelli@DESKTOP-U8OKFP3:~/tmp$ cat t.py
from __future__ import annotations

from typing import Protocol
from typing_extensions import Self


class Cat(Protocol):
    def add(self, other: Self) -> Self:
        ...
    def sub(self, other: Self) -> Self:
        ...


class FancyCat(Cat):
    def __init__(self, value: int):
        self._value = value

    def add(self, other: Self) -> FancyCat:
        return FancyCat(self._value + other._value)

(.venv) marcogorelli@DESKTOP-U8OKFP3:~/tmp$ mypy t.py
t.py:19: error: Cannot instantiate abstract class "FancyCat" with abstract attribute "sub"  [abstract]
Found 1 error in 1 file (checked 1 source file)
```

"oh, right, I didn't implement `sub`. let me add that"

```diff
+    def sub(self, other: Self) -> FancyCat:
+        return FancyCat(self._value - other._value)
```

```console
$ mypy t.py
Success: no issues found in 1 source file
```