### PR TITLE
use other: Self instead of other: Column

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,6 +27,6 @@ jobs:
             ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-build-${{ matrix.python-version }}
       - name: install-reqs
-        run: python -m pip install --upgrade mypy==1.4.0
+        run: python -m pip install --upgrade mypy==1.4.0 typing-extensions
       - name: run mypy
         run: cd spec/API_specification && mypy dataframe_api && mypy examples

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -4,6 +4,7 @@ from typing import Any,NoReturn, TYPE_CHECKING, Literal, Generic
 
 if TYPE_CHECKING:
     from .typing import NullType, Scalar, DType, Namespace
+    from typing_extensions import Self
 
 
 __all__ = ['Column']
@@ -70,21 +71,21 @@ class Column:
         Return data type of column.
         """
 
-    def get_rows(self: Column, indices: Column) -> Column:
+    def get_rows(self, indices: Self) -> Self:
         """
         Select a subset of rows, similar to `ndarray.take`.
 
         Parameters
         ----------
-        indices : Column
+        indices
             Positions of rows to select.
         """
         ...
 
 
     def slice_rows(
-        self: Column, start: int | None, stop: int | None, step: int | None
-    ) -> Column:
+        self, start: int | None, stop: int | None, step: int | None
+    ) -> Self:
         """
         Select a subset of rows corresponding to a slice.
 
@@ -101,13 +102,13 @@ class Column:
         ...
 
 
-    def filter(self: Column, mask: Column) -> Column:
+    def filter(self, mask: Self) -> Self:
         """
         Select a subset of rows corresponding to a mask.
 
         Parameters
         ----------
-        mask : Column
+        mask : Self
 
         Returns
         -------
@@ -143,7 +144,7 @@ class Column:
         *,
         ascending: bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
-    ) -> Column:
+    ) -> Self:
         """
         Sort column.
 
@@ -172,7 +173,7 @@ class Column:
         *,
         ascending: bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
-    ) -> Column:
+    ) -> Self:
         """
         Return row numbers which would sort column.
 
@@ -195,7 +196,7 @@ class Column:
         """
         ...
 
-    def __eq__(self, other: Column | Scalar) -> Column:  # type: ignore[override]
+    def __eq__(self, other: Self | Scalar) -> Self:  # type: ignore[override]
         """
         Compare for equality.
 
@@ -203,7 +204,7 @@ class Column:
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -213,7 +214,7 @@ class Column:
         Column
         """
 
-    def __ne__(self: Column, other: Column | Scalar) -> Column:  # type: ignore[override]
+    def __ne__(self, other: Self | Scalar) -> Self:  # type: ignore[override]
         """
         Compare for non-equality.
 
@@ -221,7 +222,7 @@ class Column:
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -231,13 +232,13 @@ class Column:
         Column
         """
 
-    def __ge__(self: Column, other: Column | Scalar) -> Column:
+    def __ge__(self, other: Self | Scalar) -> Self:
         """
         Compare for "greater than or equal to" `other`.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -247,13 +248,13 @@ class Column:
         Column
         """
 
-    def __gt__(self: Column, other: Column | Scalar) -> Column:
+    def __gt__(self, other: Self | Scalar) -> Self:
         """
         Compare for "greater than" `other`.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -263,13 +264,13 @@ class Column:
         Column
         """
 
-    def __le__(self: Column, other: Column | Scalar) -> Column:
+    def __le__(self, other: Self | Scalar) -> Self:
         """
         Compare for "less than or equal to" `other`.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -279,13 +280,13 @@ class Column:
         Column
         """
 
-    def __lt__(self: Column, other: Column | Scalar) -> Column:
+    def __lt__(self, other: Self | Scalar) -> Self:
         """
         Compare for "less than" `other`.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -295,7 +296,7 @@ class Column:
         Column
         """
 
-    def __and__(self: Column, other: Column | bool) -> Column:
+    def __and__(self, other: Self | bool) -> Self:
         """
         Apply logical 'and' to `other` Column (or scalar) and this Column.
 
@@ -303,7 +304,7 @@ class Column:
 
         Parameters
         ----------
-        other : Column or bool
+        other : Self or bool
             If Column, must have same length.
 
         Returns
@@ -316,7 +317,7 @@ class Column:
             If `self` or `other` is not boolean.
         """
 
-    def __or__(self: Column, other: Column | bool) -> Column:
+    def __or__(self, other: Self | bool) -> Self:
         """
         Apply logical 'or' to `other` Column (or scalar) and this column.
 
@@ -324,7 +325,7 @@ class Column:
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
 
         Returns
@@ -337,13 +338,13 @@ class Column:
             If `self` or `other` is not boolean.
         """
 
-    def __add__(self: Column, other: Column | Scalar) -> Column:
+    def __add__(self, other: Self | Scalar) -> Self:
         """
         Add `other` column or scalar to this column.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -353,13 +354,13 @@ class Column:
         Column
         """
 
-    def __sub__(self: Column, other: Column | Scalar) -> Column:
+    def __sub__(self, other: Self | Scalar) -> Self:
         """
         Subtract `other` column or scalar from this column.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -369,13 +370,13 @@ class Column:
         Column
         """
 
-    def __mul__(self, other: Column | Scalar) -> Column:
+    def __mul__(self, other: Self | Scalar) -> Self:
         """
         Multiply `other` column or scalar with this column.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -385,13 +386,13 @@ class Column:
         Column
         """
 
-    def __truediv__(self, other: Column | Scalar) -> Column:
+    def __truediv__(self, other: Self | Scalar) -> Self:
         """
         Divide this column by `other` column or scalar. True division, returns floats.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -401,13 +402,13 @@ class Column:
         Column
         """
 
-    def __floordiv__(self, other: Column | Scalar) -> Column:
+    def __floordiv__(self, other: Self | Scalar) -> Self:
         """
         Floor-divide `other` column or scalar to this column.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -417,7 +418,7 @@ class Column:
         Column
         """
 
-    def __pow__(self, other: Column | Scalar) -> Column:
+    def __pow__(self, other: Self | Scalar) -> Self:
         """
         Raise this column to the power of `other`.
 
@@ -427,7 +428,7 @@ class Column:
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -437,13 +438,13 @@ class Column:
         Column
         """
 
-    def __mod__(self, other: Column | Scalar) -> Column:
+    def __mod__(self, other: Self | Scalar) -> Self:
         """
         Returns modulus of this column by `other` (`%` operator).
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -453,13 +454,13 @@ class Column:
         Column
         """
 
-    def __divmod__(self, other: Column | Scalar) -> tuple[Column, Column]:
+    def __divmod__(self, other: Self | Scalar) -> tuple[Column, Column]:
         """
         Return quotient and remainder of integer division. See `divmod` builtin function.
 
         Parameters
         ----------
-        other : Column or Scalar
+        other : Self or Scalar
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
@@ -469,26 +470,26 @@ class Column:
         Column
         """
 
-    def __radd__(self: Column, other: Column | Scalar) -> Column:
+    def __radd__(self, other: Self | Scalar) -> Self:
         ...
-    def __rsub__(self: Column, other: Column | Scalar) -> Column:
+    def __rsub__(self, other: Self | Scalar) -> Self:
         ...
-    def __rmul__(self, other: Column | Scalar) -> Column:
+    def __rmul__(self, other: Self | Scalar) -> Self:
         ...
-    def __rtruediv__(self, other: Column | Scalar) -> Column:
+    def __rtruediv__(self, other: Self | Scalar) -> Self:
         ...
-    def __rand__(self: Column, other: Column | bool) -> Column:
+    def __rand__(self, other: Self | bool) -> Self:
         ...
-    def __ror__(self: Column, other: Column | bool) -> Column:
+    def __ror__(self, other: Self | bool) -> Self:
         ...
-    def __rfloordiv__(self, other: Column | Scalar) -> Column:
+    def __rfloordiv__(self, other: Self | Scalar) -> Self:
         ...
-    def __rpow__(self, other: Column | Scalar) -> Column:
+    def __rpow__(self, other: Self | Scalar) -> Self:
         ...
-    def __rmod__(self, other: Column | Scalar) -> Column:
+    def __rmod__(self, other: Self | Scalar) -> Self:
         ...
 
-    def __invert__(self: Column) -> Column:
+    def __invert__(self) -> Self:
         """
         Invert truthiness of (boolean) elements.
 
@@ -498,7 +499,7 @@ class Column:
             If any of the Column's columns is not boolean.
         """
 
-    def any(self: Column, *, skip_nulls: bool = True) -> bool | NullType:
+    def any(self, *, skip_nulls: bool = True) -> bool | NullType:
         """
         Reduction returns a bool.
 
@@ -508,7 +509,7 @@ class Column:
             If column is not boolean.
         """
 
-    def all(self: Column, *, skip_nulls: bool = True) -> bool | NullType:
+    def all(self, *, skip_nulls: bool = True) -> bool | NullType:
         """
         Reduction returns a bool.
 
@@ -602,33 +603,33 @@ class Column:
             Whether to skip null values.
         """
 
-    def cumulative_max(self: Column) -> Column:
+    def cumulative_max(self) -> Self:
         """
         Reduction returns a Column. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def cumulative_min(self: Column) -> Column:
+    def cumulative_min(self) -> Self:
         """
         Reduction returns a Column. Any data type that supports comparisons
         must be supported. The returned value has the same dtype as the column.
         """
 
-    def cumulative_sum(self: Column) -> Column:
+    def cumulative_sum(self) -> Self:
         """
         Reduction returns a Column. Must be supported for numerical and
         datetime data types. The returned value has the same dtype as the
         column.
         """
 
-    def cumulative_prod(self: Column) -> Column:
+    def cumulative_prod(self) -> Self:
         """
         Reduction returns a Column. Must be supported for numerical and
         datetime data types. The returned value has the same dtype as the
         column.
         """
 
-    def is_null(self) -> Column:
+    def is_null(self) -> Self:
         """
         Check for 'missing' or 'null' entries.
 
@@ -647,7 +648,7 @@ class Column:
         but note that the Standard makes no guarantees about them.
         """
 
-    def is_nan(self) -> Column:
+    def is_nan(self) -> Self:
         """
         Check for nan entries.
 
@@ -666,13 +667,13 @@ class Column:
         In particular, does not check for `np.timedelta64('NaT')`.
         """
 
-    def is_in(self: Column, values: Column) -> Column:
+    def is_in(self, values: Self) -> Self:
         """
         Indicate whether the value at each row matches any value in `values`.
 
         Parameters
         ----------
-        values : Column
+        values : Self
             Contains values to compare against. May include ``float('nan')`` and
             ``null``, in which case ``'nan'`` and ``null`` will
             respectively return ``True`` even though ``float('nan') == float('nan')``
@@ -684,7 +685,7 @@ class Column:
         Column
         """
 
-    def unique_indices(self, *, skip_nulls: bool = True) -> Column:
+    def unique_indices(self, *, skip_nulls: bool = True) -> Self:
         """
         Return indices corresponding to unique values in Column.
 
@@ -705,7 +706,7 @@ class Column:
         """
         ...
 
-    def fill_nan(self: Column, value: float | NullType, /) -> Column:
+    def fill_nan(self, value: float | NullType, /) -> Self:
         """
         Fill floating point ``nan`` values with the given fill value.
 
@@ -719,7 +720,7 @@ class Column:
         """
         ...
 
-    def fill_null(self: Column, value: Scalar, /) -> Column:
+    def fill_null(self, value: Scalar, /) -> Self:
         """
         Fill null values with the given fill value.
 
@@ -767,7 +768,7 @@ class Column:
         ``array-api-compat`` package to convert it to a Standard-compliant array.
         """
 
-    def rename(self, name: str) -> Column:
+    def rename(self, name: str) -> Self:
         """
         Rename column.
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from .column_object import Column
     from .groupby_object import GroupBy
     from .typing import NullType, Scalar, Namespace, DType, SupportsDataFrameAPI
+    from typing_extensions import Self
 
 
 __all__ = ["DataFrame"]
@@ -108,7 +109,7 @@ class DataFrame:
         """
         ...
 
-    def select(self, names: Sequence[str], /) -> DataFrame:
+    def select(self, names: Sequence[str], /) -> Self:
         """
         Select multiple columns by name.
 
@@ -127,7 +128,7 @@ class DataFrame:
         """
         ...
 
-    def get_rows(self, indices: Column) -> DataFrame:
+    def get_rows(self, indices: Column) -> Self:
         """
         Select a subset of rows, similar to `ndarray.take`.
 
@@ -144,7 +145,7 @@ class DataFrame:
 
     def slice_rows(
         self, start: int | None, stop: int | None, step: int | None
-    ) -> DataFrame:
+    ) -> Self:
         """
         Select a subset of rows corresponding to a slice.
 
@@ -160,7 +161,7 @@ class DataFrame:
         """
         ...
 
-    def filter(self, mask: Column) -> DataFrame:
+    def filter(self, mask: Column) -> Self:
         """
         Select a subset of rows corresponding to a mask.
 
@@ -179,7 +180,7 @@ class DataFrame:
         """
         ...
 
-    def assign(self, columns: Column | Sequence[Column], /) -> DataFrame:
+    def assign(self, columns: Column | Sequence[Column], /) -> Self:
         """
         Insert new column(s), or update values in existing ones.
 
@@ -207,7 +208,7 @@ class DataFrame:
         """
         ...
 
-    def drop_columns(self, label: str | list[str]) -> DataFrame:
+    def drop_columns(self, label: str | list[str]) -> Self:
         """
         Drop the specified column(s).
 
@@ -227,7 +228,7 @@ class DataFrame:
         """
         ...
 
-    def rename_columns(self, mapping: Mapping[str, str]) -> DataFrame:
+    def rename_columns(self, mapping: Mapping[str, str]) -> Self:
         """
         Rename columns.
 
@@ -270,7 +271,7 @@ class DataFrame:
         *,
         ascending: Sequence[bool] | bool = True,
         nulls_position: Literal['first', 'last'] = 'last',
-    ) -> DataFrame:
+    ) -> Self:
         """
         Sort dataframe according to given columns.
 
@@ -345,7 +346,7 @@ class DataFrame:
         """
         ...
 
-    def __eq__(self, other: Scalar) -> DataFrame:  # type: ignore[override]
+    def __eq__(self, other: Scalar) -> Self:  # type: ignore[override]
         """
         Compare for equality.
 
@@ -363,7 +364,7 @@ class DataFrame:
         """
         ...
 
-    def __ne__(self, other: Scalar) -> DataFrame:  # type: ignore[override]
+    def __ne__(self, other: Scalar) -> Self:  # type: ignore[override]
         """
         Compare for non-equality.
 
@@ -381,7 +382,7 @@ class DataFrame:
         """
         ...
 
-    def __ge__(self, other: Scalar) -> DataFrame:
+    def __ge__(self, other: Scalar) -> Self:
         """
         Compare for "greater than or equal to" `other`.
 
@@ -397,7 +398,7 @@ class DataFrame:
         """
         ...
 
-    def __gt__(self, other: Scalar) -> DataFrame:
+    def __gt__(self, other: Scalar) -> Self:
         """
         Compare for "greater than" `other`.
 
@@ -413,7 +414,7 @@ class DataFrame:
         """
         ...
 
-    def __le__(self, other: Scalar) -> DataFrame:
+    def __le__(self, other: Scalar) -> Self:
         """
         Compare for "less than or equal to" `other`.
 
@@ -429,7 +430,7 @@ class DataFrame:
         """
         ...
 
-    def __lt__(self, other: Scalar) -> DataFrame:
+    def __lt__(self, other: Scalar) -> Self:
         """
         Compare for "less than" `other`.
 
@@ -445,7 +446,7 @@ class DataFrame:
         """
         ...
 
-    def __and__(self, other: bool) -> DataFrame:
+    def __and__(self, other: bool) -> Self:
         """
         Apply logical 'and' to `other` scalar and this dataframe.
 
@@ -465,7 +466,7 @@ class DataFrame:
             If `self` or `other` is not boolean.
         """
 
-    def __or__(self, other: DataFrame | bool) -> DataFrame:
+    def __or__(self, other: bool) -> Self:
         """
         Apply logical 'or' to `other` scalar and this DataFrame.
 
@@ -485,7 +486,7 @@ class DataFrame:
             If `self` or `other` is not boolean.
         """
 
-    def __add__(self, other: Scalar) -> DataFrame:
+    def __add__(self, other: Scalar) -> Self:
         """
         Add `other` scalar to this dataframe.
 
@@ -501,7 +502,7 @@ class DataFrame:
         """
         ...
 
-    def __sub__(self, other: Scalar) -> DataFrame:
+    def __sub__(self, other: Scalar) -> Self:
         """
         Subtract `other` scalar from this dataframe.
 
@@ -517,7 +518,7 @@ class DataFrame:
         """
         ...
 
-    def __mul__(self, other: Scalar) -> DataFrame:
+    def __mul__(self, other: Scalar) -> Self:
         """
         Multiply  `other` scalar with this dataframe.
 
@@ -533,7 +534,7 @@ class DataFrame:
         """
         ...
 
-    def __truediv__(self, other: Scalar) -> DataFrame:
+    def __truediv__(self, other: Scalar) -> Self:
         """
         Divide  this dataframe by `other` scalar. True division, returns floats.
 
@@ -549,7 +550,7 @@ class DataFrame:
         """
         ...
 
-    def __floordiv__(self, other: Scalar) -> DataFrame:
+    def __floordiv__(self, other: Scalar) -> Self:
         """
         Floor-divide (returns integers) this dataframe by `other` scalar.
 
@@ -565,7 +566,7 @@ class DataFrame:
         """
         ...
 
-    def __pow__(self, other: Scalar) -> DataFrame:
+    def __pow__(self, other: Scalar) -> Self:
         """
         Raise this dataframe to the power of `other`.
 
@@ -585,7 +586,7 @@ class DataFrame:
         """
         ...
 
-    def __mod__(self, other: Scalar) -> DataFrame:
+    def __mod__(self, other: Scalar) -> Self:
         """
         Return modulus of this dataframe by `other` (`%` operator).
 
@@ -617,26 +618,26 @@ class DataFrame:
         """
         ...
 
-    def __radd__(self, other: Scalar) -> DataFrame:
+    def __radd__(self, other: Scalar) -> Self:
         ...
-    def __rsub__(self, other: Scalar) -> DataFrame:
+    def __rsub__(self, other: Scalar) -> Self:
         ...
-    def __rmul__(self, other: Scalar) -> DataFrame:
+    def __rmul__(self, other: Scalar) -> Self:
         ...
-    def __rtruediv__(self, other: Scalar) -> DataFrame:
+    def __rtruediv__(self, other: Scalar) -> Self:
         ...
-    def __rand__(self, other: Scalar) -> DataFrame:
+    def __rand__(self, other: Scalar) -> Self:
         ...
-    def __ror__(self, other: Scalar) -> DataFrame:
+    def __ror__(self, other: Scalar) -> Self:
         ...
-    def __rfloordiv__(self, other: Scalar) -> DataFrame:
+    def __rfloordiv__(self, other: Scalar) -> Self:
         ...
-    def __rpow__(self, other: Scalar) -> DataFrame:
+    def __rpow__(self, other: Scalar) -> Self:
         ...
-    def __rmod__(self, other: Scalar) -> DataFrame:
+    def __rmod__(self, other: Scalar) -> Self:
         ...
 
-    def __invert__(self) -> DataFrame:
+    def __invert__(self) -> Self:
         """
         Invert truthiness of (boolean) elements.
 
@@ -659,7 +660,7 @@ class DataFrame:
         """
         raise NotImplementedError("'__iter__' is intentionally not implemented.")
 
-    def any(self, *, skip_nulls: bool = True) -> DataFrame:
+    def any(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
 
@@ -670,7 +671,7 @@ class DataFrame:
         """
         ...
 
-    def all(self, *, skip_nulls: bool = True) -> DataFrame:
+    def all(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
 
@@ -709,58 +710,43 @@ class DataFrame:
         """
         ...
 
-    def min(self, *, skip_nulls: bool = True) -> DataFrame:
+    def min(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
         """
         ...
 
-    def max(self, *, skip_nulls: bool = True) -> DataFrame:
+    def max(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
         """
         ...
 
-    def sum(self, *, skip_nulls: bool = True) -> DataFrame:
+    def sum(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
         """
         ...
 
-    def prod(self, *, skip_nulls: bool = True) -> DataFrame:
+    def prod(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
         """
         ...
 
-    def median(self, *, skip_nulls: bool = True) -> DataFrame:
+    def median(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
         """
         ...
 
-    def mean(self, *, skip_nulls: bool = True) -> DataFrame:
+    def mean(self, *, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
         """
         ...
 
-    def std(self, *, correction: int | float = 1, skip_nulls: bool = True) -> DataFrame:
-        """
-        Reduction returns a 1-row DataFrame.
-
-        Parameters
-        ----------
-        correction
-            Correction to apply to the result. For example, ``0`` for sample
-            standard deviation and ``1`` for population standard deviation.
-            See `Column.std` for a more detailed description.
-        skip_nulls
-            Whether to skip null values.
-        """
-        ...
-
-    def var(self, *, correction: int | float = 1, skip_nulls: bool = True) -> DataFrame:
+    def std(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Self:
         """
         Reduction returns a 1-row DataFrame.
 
@@ -775,7 +761,22 @@ class DataFrame:
         """
         ...
 
-    def is_null(self) -> DataFrame:
+    def var(self, *, correction: int | float = 1, skip_nulls: bool = True) -> Self:
+        """
+        Reduction returns a 1-row DataFrame.
+
+        Parameters
+        ----------
+        correction
+            Correction to apply to the result. For example, ``0`` for sample
+            standard deviation and ``1`` for population standard deviation.
+            See `Column.std` for a more detailed description.
+        skip_nulls
+            Whether to skip null values.
+        """
+        ...
+
+    def is_null(self) -> Self:
         """
         Check for 'missing' or 'null' entries.
 
@@ -795,7 +796,7 @@ class DataFrame:
         """
         ...
 
-    def is_nan(self) -> DataFrame:
+    def is_nan(self) -> Self:
         """
         Check for nan entries.
 
@@ -842,7 +843,7 @@ class DataFrame:
         """
         ...
 
-    def fill_nan(self, value: float | NullType, /) -> DataFrame:
+    def fill_nan(self, value: float | NullType, /) -> Self:
         """
         Fill ``nan`` values with the given fill value.
 
@@ -861,7 +862,7 @@ class DataFrame:
 
     def fill_null(
         self, value: Scalar, /, *, column_names : list[str] | None = None
-    ) -> DataFrame:
+    ) -> Self:
         """
         Fill null values with the given fill value.
 
@@ -928,12 +929,12 @@ class DataFrame:
     
     def join(
         self,
-        other: DataFrame,
+        other: Self,
         *,
         how: Literal['left', 'inner', 'outer'],
         left_on: str | list[str],
         right_on: str | list[str],
-    ) -> DataFrame:
+    ) -> Self:
         """
         Join with other dataframe.
 
@@ -943,7 +944,7 @@ class DataFrame:
 
         Parameters
         ----------
-        other : DataFrame
+        other : Self
             Dataframe to join with.
         how : str
             Kind of join to perform.

--- a/spec/conf.py
+++ b/spec/conf.py
@@ -87,6 +87,7 @@ nitpick_ignore = [
     ('py:class', 'NullType'),
     ('py:class', 'Namespace'),
     ('py:class', 'SupportsDataFrameAPI'),
+    ('py:class', 'Self'),
 ]
 # NOTE: this alias handling isn't used yet - added in anticipation of future
 #       need based on dataframe API aliases.


### PR DESCRIPTION
We're not saying that
```python
s1: PandasColumn
s2: FancyColumn
s1 + s2
```
is supported, so let's use `Self`

Else implementations will get
```console
t.py:18: error: Argument 1 of "add" is incompatible with supertype "Cat"; supertype defines the argument type as "Cat"  [override]
t.py:18: note: This violates the Liskov substitution principle
t.py:18: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
t.py:21: error: Argument 1 of "sub" is incompatible with supertype "Cat"; supertype defines the argument type as "Cat"  [override]
t.py:21: note: This violates the Liskov substitution principle
t.py:21: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
Found 2 errors in 1 file (checked 1 source file)
```