### PR TITLE
rename to_array_object to to_array, remove `dtype` argument in Column case

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -732,27 +732,26 @@ class Column:
         """
         ...
 
-    def to_array_object(self, dtype: DType) -> Any:
+    def to_array(self) -> Any:
         """
         Convert to array-API-compliant object.
 
-        Parameters
-        ----------
-        dtype : DType
-            The dtype of the array-API-compliant object to return.
-            Must be one of:
+        The resulting array will have the corresponding dtype from the
+        Array API:
 
-            - Bool()
-            - Int8()
-            - Int16()
-            - Int32()
-            - Int64()
-            - UInt8()
-            - UInt16()
-            - UInt32()
-            - UInt64()
-            - Float32()
-            - Float64()
+        - Bool() -> 'bool'
+        - Int8() -> 'int8'
+        - Int16() -> 'int16'
+        - Int32() -> 'int32'
+        - Int64() -> 'int64'
+        - UInt8() -> 'uint8'
+        - UInt16() -> 'uint16'
+        - UInt32() -> 'uint32'
+        - UInt64() -> 'uint64'
+        - Float32() -> 'float32'
+        - Float64() -> 'float64'
+    
+        Null values are not supported and must be filled prior to conversion.
         
         Returns
         -------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -891,7 +891,7 @@ class DataFrame:
         """
         ...
     
-    def to_array_object(self, dtype: DType) -> Any:
+    def to_array(self, dtype: DType) -> Any:
         """
         Convert to array-API-compliant object.
 

--- a/spec/API_specification/examples/02_plotting.py
+++ b/spec/API_specification/examples/02_plotting.py
@@ -23,7 +23,7 @@ def group_by_and_plot(
     df = namespace.dataframe_from_dict({"x": x, "y": y, "color": color})
 
     agg = df.group_by("color").mean()
-    x = agg.get_column_by_name("x").to_array_object(namespace.Float64())
-    y = agg.get_column_by_name("y").to_array_object(namespace.Float64())
+    x = agg.get_column_by_name("x").to_array(namespace.Float64())
+    y = agg.get_column_by_name("y").to_array(namespace.Float64())
 
     my_plotting_function(x, y)

--- a/spec/API_specification/examples/02_plotting.py
+++ b/spec/API_specification/examples/02_plotting.py
@@ -22,8 +22,8 @@ def group_by_and_plot(
 
     df = namespace.dataframe_from_dict({"x": x, "y": y, "color": color})
 
-    agg = df.group_by("color").mean()
-    x = agg.get_column_by_name("x").to_array(namespace.Float64())
-    y = agg.get_column_by_name("y").to_array(namespace.Float64())
+    agg = df.group_by("color").mean().fill_null(float('nan'))
+    x = agg.get_column_by_name("x").to_array()
+    y = agg.get_column_by_name("y").to_array()
 
     my_plotting_function(x, y)


### PR DESCRIPTION
Couple of things here:

- `to_array_object` is quite long. The docstring already describes what exactly the method does. Could it just be `to_array` instead?
- In the Column case, can we remove the `dtype` argument? Much simpler to just convert to the respective dtype, and "force" users to fill nulls before hand