### PR TITLE
Note that comparisons between columns from different dataframes is outside the standard

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -211,6 +211,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __ne__(self: Column, other: Column | Scalar) -> Column:  # type: ignore[override]
@@ -229,6 +235,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __ge__(self: Column, other: Column | Scalar) -> Column:
@@ -245,6 +257,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __gt__(self: Column, other: Column | Scalar) -> Column:
@@ -261,6 +279,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __le__(self: Column, other: Column | Scalar) -> Column:
@@ -277,6 +301,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __lt__(self: Column, other: Column | Scalar) -> Column:
@@ -293,6 +323,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __and__(self: Column, other: Column | bool) -> Column:
@@ -314,6 +350,12 @@ class Column:
         ------
         ValueError
             If `self` or `other` is not boolean.
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __or__(self: Column, other: Column | bool) -> Column:
@@ -335,6 +377,12 @@ class Column:
         ------
         ValueError
             If `self` or `other` is not boolean.
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __add__(self: Column, other: Column | Scalar) -> Column:
@@ -351,6 +399,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __sub__(self: Column, other: Column | Scalar) -> Column:
@@ -367,6 +421,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __mul__(self, other: Column | Scalar) -> Column:
@@ -383,6 +443,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __truediv__(self, other: Column | Scalar) -> Column:
@@ -399,6 +465,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __floordiv__(self, other: Column | Scalar) -> Column:
@@ -415,6 +487,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __pow__(self, other: Column | Scalar) -> Column:
@@ -435,6 +513,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __mod__(self, other: Column | Scalar) -> Column:
@@ -451,6 +535,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __divmod__(self, other: Column | Scalar) -> tuple[Column, Column]:
@@ -467,6 +557,12 @@ class Column:
         Returns
         -------
         Column
+
+        Notes
+        -----
+        If `other` is a `Column`, then the Standard only supports the case when `other`
+        and `self` originated from the same dataframe. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
 
     def __radd__(self: Column, other: Column | Scalar) -> Column:

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -139,6 +139,12 @@ class DataFrame:
         Returns
         -------
         DataFrame
+
+        Notes
+        -----
+        The Standard only supports the case when `indices`
+        originated from `self`. If it didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
         ...
 
@@ -174,8 +180,9 @@ class DataFrame:
 
         Notes
         -----
-        Some participants preferred a weaker type Arraylike[bool] for mask,
-        where 'Arraylike' denotes an object adhering to the Array API standard.
+        The Standard only supports the case when `mask`
+        originated from `self`. If it didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
         ...
 
@@ -204,6 +211,12 @@ class DataFrame:
         Returns
         -------
         DataFrame
+
+        Notes
+        -----
+        The Standard only supports the case when `columns`
+        originated from `self`. If they didn't, then behaviour
+        is unspecified and may vary across implementations.
         """
         ...
 


### PR DESCRIPTION
This has come up a few times

https://github.com/data-apis/dataframe-api/pull/249#issuecomment-1769254879

> Are folks open to simply saying that the operation is undefined by the existing standard? Implementations can choose to raise

https://github.com/data-apis/dataframe-api/issues/287#issuecomment-1777097662

> On way to do [Column.mean() whilst not having to materialise more times than necessary when filtering] is for the column to keep track of its originating DataFrame:

---

so let's document that it's outside the standard?