### PR TITLE
remove `names` from dataframe_from_2d_array

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -137,7 +137,7 @@ def column_from_1d_array(array: Any, *, dtype: DType, name: str = '') -> Column:
     """
     ...
 
-def dataframe_from_2d_array(array: Any, *, dtypes: Dict[str, Any]) -> DataFrame:
+def dataframe_from_2d_array(array: Any, *, schema: Dict[str, DType]) -> DataFrame:
     """
     Construct DataFrame from 2D array.
 

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -135,7 +135,7 @@ def column_from_1d_array(array: Any, *, dtype: DType, name: str = '') -> Column:
     """
     ...
 
-def dataframe_from_2d_array(array: Any, *, names: Sequence[str], dtypes: Mapping[str, Any]) -> DataFrame:
+def dataframe_from_2d_array(array: Any, *, dtypes: Mapping[str, Any]) -> DataFrame:
     """
     Construct DataFrame from 2D array.
 
@@ -149,10 +149,9 @@ def dataframe_from_2d_array(array: Any, *, names: Sequence[str], dtypes: Mapping
     ----------
     array : array
         array-API compliant 2D array
-    names : Sequence[str]
-        Names to give columns. Must be the same length as ``array.shape[1]``.
     dtypes : Mapping[str, DType]
         Dtype of each column. Must be the same length as ``array.shape[1]``.
+        Keys determine column names.
 
     Returns
     -------

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -4,7 +4,7 @@ Function stubs and API documentation for the DataFrame API standard.
 """
 from __future__ import annotations
 
-from typing import Mapping, Sequence, Any, Literal, TYPE_CHECKING
+from typing import Dict, Sequence, Any, TYPE_CHECKING
 
 from .column_object import *
 from .dataframe_object import DataFrame
@@ -137,7 +137,7 @@ def column_from_1d_array(array: Any, *, dtype: DType, name: str = '') -> Column:
     """
     ...
 
-def dataframe_from_2d_array(array: Any, *, dtypes: Mapping[str, Any]) -> DataFrame:
+def dataframe_from_2d_array(array: Any, *, dtypes: Dict[str, Any]) -> DataFrame:
     """
     Construct DataFrame from 2D array.
 
@@ -203,8 +203,8 @@ def is_null(value: object, /) -> bool:
     bool
         True if the input is a `null` object from the same library which
         implements the dataframe API standard, False otherwise.
-
     """
+    ...
 
 def is_dtype(dtype: DType, kind: str | tuple[str, ...]) -> bool:
     """
@@ -236,6 +236,7 @@ def is_dtype(dtype: DType, kind: str | tuple[str, ...]) -> bool:
     -------
     bool
     """
+    ...
 
 def date(year: int, month: int, day: int) -> Scalar:
     """

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -47,6 +47,7 @@ class Column(Protocol):
     @property
     def name(self) -> str:
         """Return name of column."""
+        ...
 
     def __len__(self) -> int:
         """

--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -121,7 +121,7 @@ class Namespace(Protocol):
         self,
         sequence: Sequence[Any],
         *,
-        dtype: Any,
+        dtype: DType,
         name: str = "",
     ) -> Column:
         ...
@@ -130,7 +130,7 @@ class Namespace(Protocol):
         ...
 
     def column_from_1d_array(
-        self, array: Any, *, dtype: Any, name: str = ""
+        self, array: Any, *, dtype: DType, name: str = ""
     ) -> Column:
         ...
 
@@ -139,14 +139,14 @@ class Namespace(Protocol):
         array: Any,
         *,
         names: Sequence[str],
-        dtypes: Mapping[str, Any],
+        schema: Mapping[str, DType],
     ) -> DataFrame:
         ...
 
     def is_null(self, value: object, /) -> bool:
         ...
 
-    def is_dtype(self, dtype: Any, kind: str | tuple[str, ...]) -> bool:
+    def is_dtype(self, dtype: DType, kind: str | tuple[str, ...]) -> bool:
         ...
     
     def date(self, year: int, month: int, day: int) -> Scalar:


### PR DESCRIPTION
The keys of `dtypes` already give the column names, and Python dicts are ordered

If anyone needs to reorder the names after construction, they can put `.select` after this method anyway

But having to always provide both `dtypes` and `names` is quite annoying from a user perspective