### PR TITLE
fix typing of dataframe_from_2d_array

### DIFF
--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -7,7 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Mapping,
+    Dict,
     Protocol,
     Sequence,
     Union,
@@ -138,8 +138,7 @@ class Namespace(Protocol):
         self,
         array: Any,
         *,
-        names: Sequence[str],
-        schema: Mapping[str, DType],
+        schema: Dict[str, DType],
     ) -> DataFrame:
         ...
 


### PR DESCRIPTION
It's going to be quite annoying to have to keep this class in-sync with the main module - I'd suggest just making a `Namespace` Protocol class in `__init__.py`, but that's for a separate PR