### PR TITLE
remove mention of DataFrame.insert from concat docstring

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -57,8 +57,6 @@ def concat(dataframes: Sequence[DataFrame]) -> DataFrame:
     """
     Concatenate DataFrames vertically.
 
-    To concatenate horizontally, please use :meth:`DataFrame.assign`.
-
     Parameters
     ----------
     dataframes : Sequence[DataFrame]

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -57,7 +57,7 @@ def concat(dataframes: Sequence[DataFrame]) -> DataFrame:
     """
     Concatenate DataFrames vertically.
 
-    To concatenate horizontally, please use ``insert``.
+    To concatenate horizontally, please use :meth:`DataFrame.assign`.
 
     Parameters
     ----------


### PR DESCRIPTION
`DataFrame.insert` has been renamed to `DataFrame.assign`, and isn't really a complete replacement for horizontal concatenation. I'd suggest just removing the sentence for now, we can always add horizontal concatenation if/when the need arises