### PR TITLE
Add note about parent dataframes and cross-dataframe column comparisons

### DIFF
--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -238,6 +238,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -257,6 +262,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -274,6 +284,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -291,6 +306,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -308,6 +328,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -325,6 +350,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -342,6 +372,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
 
         Raises
         ------
@@ -365,6 +400,11 @@ class Column(Protocol):
         -------
         Column
 
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
+
         Raises
         ------
         ValueError
@@ -382,6 +422,11 @@ class Column(Protocol):
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
+ 
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
 
         Returns
         -------
@@ -403,6 +448,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -420,6 +470,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -437,6 +492,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -454,6 +514,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -475,6 +540,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -492,6 +562,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -509,6 +584,11 @@ class Column(Protocol):
         Returns
         -------
         Column
+
+        Notes
+        -----
+        `other`'s parent DataFrame must be the same as `self`'s - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol
 
 if TYPE_CHECKING:
     from typing_extensions import Self
+
     from dataframe_api.dataframe_object import DataFrame
 
     from .typing import DType, Namespace, NullType, Scalar
@@ -24,7 +25,7 @@ class Column(Protocol):
     plays a key role here:
 
     - If two columns were retrieved from the same dataframe,
-      then they can be combined and compared at will. 
+      then they can be combined and compared at will.
     - If two columns were retrieved from different dataframes,
       then there is no guarantee about how or whether they can be combined and
       compared, this may vary across implementations.
@@ -33,10 +34,10 @@ class Column(Protocol):
       combined and compared with each other. Note, however, that they still can't
       be compared or combined with columns retrieved from a dataframe.
     """
+
     @property
     def dataframe(self) -> DataFrame | None:
-        """
-        Return parent DataFrame, if present.
+        """Return parent DataFrame, if present.
 
         For example, if we have the following
 
@@ -44,7 +45,7 @@ class Column(Protocol):
 
             df: DataFrame
             column = df.col('a')
-        
+
         then `column.dataframe` should return `df`.
 
         On the other hand, if we had:
@@ -52,7 +53,7 @@ class Column(Protocol):
         .. code-block:: python
 
             column = column_from_1d_array(...)
-        
+
         then `column.dataframe` should return `None`.
         """
 
@@ -413,7 +414,7 @@ class Column(Protocol):
             If Column, must have same length.
             "Scalar" here is defined implicitly by what scalar types are allowed
             for the operation by the underling dtypes.
- 
+
         Notes
         -----
         `other`'s parent DataFrame must be the same as `self`'s - else,

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -19,6 +19,19 @@ class Column(Protocol):
     users of the library implementing the dataframe API standard. Rather, use
     constructor functions or an already-created dataframe object retrieved via
     :meth:`DataFrame.col`.
+
+    The parent dataframe (which can be retrieved via the :meth:`dataframe` property)
+    plays a key role here:
+
+    - If two columns were retrieved from the same dataframe,
+      then they can be combined and compared at will. 
+    - If two columns were retrieved from different dataframes,
+      then there is no guarantee about how or whether they can be combined and
+      compared, this may vary across implementations.
+    - If two columns are both "free-standing" (i.e. not retrieved from a dataframe
+      but constructed directly from a 1D array or sequence), then they can be
+      combined and compared with each other. Note, however, that they still can't
+      be compared or combined with columns retrieved from a dataframe.
     """
     @property
     def dataframe(self) -> DataFrame | None:

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -5,6 +5,7 @@ from typing import Any,NoReturn, TYPE_CHECKING, Literal, Protocol
 if TYPE_CHECKING:
     from .typing import NullType, Scalar, DType, Namespace
     from typing_extensions import Self
+    from dataframe_api.dataframe_object import DataFrame
 
 
 __all__ = ['Column']
@@ -17,8 +18,30 @@ class Column(Protocol):
     Note that this column object is not meant to be instantiated directly by
     users of the library implementing the dataframe API standard. Rather, use
     constructor functions or an already-created dataframe object retrieved via
-
+    :meth:`DataFrame.col`.
     """
+    @property
+    def dataframe(self) -> DataFrame | None:
+        """
+        Return parent DataFrame, if present.
+
+        For example, if we have the following
+
+        .. code-block:: python
+
+            df: DataFrame
+            column = df.col('a')
+        
+        then `column.dataframe` should return `df`.
+
+        On the other hand, if we had:
+
+        .. code-block:: python
+
+            column = column_from_1d_array(...)
+        
+        then `column.dataframe` should return `None`.
+        """
 
     def __column_namespace__(self) -> Namespace:
         """

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -21,8 +21,8 @@ class Column(Protocol):
     constructor functions or an already-created dataframe object retrieved via
     :meth:`DataFrame.col`.
 
-    The parent dataframe (which can be retrieved via the :meth:`dataframe` property)
-    plays a key role here:
+    The parent dataframe (which can be retrieved via the :meth:`parent_dataframe`
+    property) plays a key role here:
 
     - If two columns were retrieved from the same dataframe,
       then they can be combined and compared at will.
@@ -31,12 +31,13 @@ class Column(Protocol):
       compared, this may vary across implementations.
     - If two columns are both "free-standing" (i.e. not retrieved from a dataframe
       but constructed directly from a 1D array or sequence), then they can be
-      combined and compared with each other. Note, however, that they still can't
-      be compared or combined with columns retrieved from a dataframe.
+      combined and compared with each other. Note, however, that there's no guarantee
+      about whether they can be compared or combined with columns retrieved from a
+      different dataframe, this may vary across implementations.
     """
 
     @property
-    def dataframe(self) -> DataFrame | None:
+    def parent_dataframe(self) -> DataFrame | None:
         """Return parent DataFrame, if present.
 
         For example, if we have the following
@@ -46,7 +47,7 @@ class Column(Protocol):
             df: DataFrame
             column = df.col('a')
 
-        then `column.dataframe` should return `df`.
+        then `column.parent_dataframe` should return `df`.
 
         On the other hand, if we had:
 
@@ -54,7 +55,7 @@ class Column(Protocol):
 
             column = column_from_1d_array(...)
 
-        then `column.dataframe` should return `None`.
+        then `column.parent_dataframe` should return `None`.
         """
 
     def __column_namespace__(self) -> Namespace:

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -142,6 +142,11 @@ class DataFrame(Protocol):
         Returns
         -------
         DataFrame
+
+        Notes
+        -----
+        `indices`'s parent DataFrame must be `self` - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -177,8 +182,8 @@ class DataFrame(Protocol):
 
         Notes
         -----
-        Some participants preferred a weaker type Arraylike[bool] for mask,
-        where 'Arraylike' denotes an object adhering to the Array API standard.
+        `mask`'s parent DataFrame must be `self` - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 
@@ -207,6 +212,11 @@ class DataFrame(Protocol):
         Returns
         -------
         DataFrame
+
+        Notes
+        -----
+        All of `columns`'s parent DataFrame must be `self` - else,
+        the operation is unsupported and may vary across implementations.
         """
         ...
 


### PR DESCRIPTION
I think we can relax many of these restrictions for the case of free-standing columns (i.e. those without a parent dataframe, created via `column_from_1d_array`) - just working through it to check, will update this week