### PR TITLE
Make DataFrame.any_rowwise top-level, rename to _horizontal

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -292,7 +292,7 @@ def date(year: int, month: int, day: int) -> Scalar:
     """
 
 
-def any_horizontal(*columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+def any_horizontal(*columns: Column, skip_nulls: bool = True) -> Column:
     """Reduction returns a Column.
 
     Differs from :meth:`DataFrame.any` in that the reduction happens
@@ -318,7 +318,7 @@ def any_horizontal(*columns: Column, skip_nulls: bool | Scalar = True) -> Column
     ...
 
 
-def all_horizontal(*columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+def all_horizontal(*columns: Column, skip_nulls: bool = True) -> Column:
     """Reduction returns a Column.
 
     Differs from :meth:`DataFrame.all` in that the reduction happens
@@ -382,7 +382,7 @@ def sorted_indices(
     ...
 
 
-def unique_indices(*columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+def unique_indices(*columns: Column, skip_nulls: bool = True) -> Column:
     """Return indices corresponding to unique values across selected columns.
 
     Parameters

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -2,7 +2,7 @@
 """Function stubs and API documentation for the DataFrame API standard."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from .column_object import Column
 from .dataframe_object import DataFrame
@@ -340,5 +340,69 @@ def all_horizontal(*columns: Column, skip_nulls: bool | Scalar = True) -> Column
     ...     *[df.col(col_name) > 0 for col_name in df.column_names()]
     ... )
     >>> df = df.filter(mask)
+    """
+    ...
+
+
+def sorted_indices(
+    *columns: Column,
+    ascending: Sequence[bool] | bool = True,
+    nulls_position: Literal["first", "last"] = "last",
+) -> Column:
+    """Return row numbers which would sort according to given columns.
+
+    If you need to sort the DataFrame, use :meth:`sort`.
+
+    Parameters
+    ----------
+    *columns : Column
+        Columns to sort by.
+    ascending : Sequence[bool] or bool
+        If `True`, sort by all keys in ascending order.
+        If `False`, sort by all keys in descending order.
+        If a sequence, it must be the same length as `keys`,
+        and determines the direction with which to use each
+        key to sort by.
+    nulls_position : ``{'first', 'last'}``
+        Whether null values should be placed at the beginning
+        or at the end of the result.
+        Note that the position of NaNs is unspecified and may
+        vary based on the implementation.
+
+    Returns
+    -------
+    Column
+        The return value has the same parent DataFrame as the input columns.
+
+    Raises
+    ------
+    ValueError
+        If `keys` and `ascending` are sequences of different lengths.
+    """
+    ...
+
+
+def unique_indices(*columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+    """Return indices corresponding to unique values across selected columns.
+
+    Parameters
+    ----------
+    *columns : Column
+        Column names to consider when finding unique values.
+
+    Returns
+    -------
+    Column
+        Indices corresponding to unique values.
+
+    Notes
+    -----
+    There are no ordering guarantees. In particular, if there are multiple
+    indices corresponding to the same unique value(s), there is no guarantee
+    about which one will appear in the result.
+    If the original column(s) contain multiple `'NaN'` values, then
+    only a single index corresponding to those values will be returned.
+    Likewise for null values (if ``skip_nulls=False``).
+    To get the unique values, you can do ``df.get_rows(df.unique_indices(keys))``.
     """
     ...

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -290,3 +290,55 @@ def date(year: int, month: int, day: int) -> Scalar:
     ... )
     >>> df.filter(mask)
     """
+
+
+def any_horizontal(*columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+    """Reduction returns a Column.
+
+    Differs from :meth:`DataFrame.any` in that the reduction happens
+    for each row, rather than for each column.
+
+    All the `columns` must have the same parent DataFrame.
+    The return value has the same parent DataFrame as the input columns.
+
+    Raises
+    ------
+    ValueError
+        If any of the columns is not boolean.
+
+    Examples
+    --------
+    >>> df: DataFrame
+    >>> ns = df.__dataframe_namespace__()
+    >>> mask = ns.any_horizontal(
+    ...     *[df.col(col_name) > 0 for col_name in df.column_names()]
+    ... )
+    >>> df = df.filter(mask)
+    """
+    ...
+
+
+def all_horizontal(*columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+    """Reduction returns a Column.
+
+    Differs from :meth:`DataFrame.all` in that the reduction happens
+    for each row, rather than for each column.
+
+    All the `columns` must have the same parent DataFrame.
+    The return value has the same parent DataFrame as the input columns.
+
+    Raises
+    ------
+    ValueError
+        If any of the columns is not boolean.
+
+    Examples
+    --------
+    >>> df: DataFrame
+    >>> ns = df.__dataframe_namespace__()
+    >>> mask = ns.all_horizontal(
+    ...     *[df.col(col_name) > 0 for col_name in df.column_names()]
+    ... )
+    >>> df = df.filter(mask)
+    """
+    ...

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -183,7 +183,7 @@ class Column(Protocol):
         """Sort column.
 
         If you need the indices which would sort the column,
-        use :meth:`sorted_indices`.
+        use `sorted_indices`.
 
         Parameters
         ----------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -314,44 +314,6 @@ class DataFrame(Protocol):
         """
         ...
 
-    def sorted_indices(
-        self,
-        *keys: str,
-        ascending: Sequence[bool] | bool = True,
-        nulls_position: Literal["first", "last"] = "last",
-    ) -> Column:
-        """Return row numbers which would sort according to given columns.
-
-        If you need to sort the DataFrame, use :meth:`sort`.
-
-        Parameters
-        ----------
-        *keys : str
-            Names of columns to sort by.
-            If not specified, sort by all columns.
-        ascending : Sequence[bool] or bool
-            If `True`, sort by all keys in ascending order.
-            If `False`, sort by all keys in descending order.
-            If a sequence, it must be the same length as `keys`,
-            and determines the direction with which to use each
-            key to sort by.
-        nulls_position : ``{'first', 'last'}``
-            Whether null values should be placed at the beginning
-            or at the end of the result.
-            Note that the position of NaNs is unspecified and may
-            vary based on the implementation.
-
-        Returns
-        -------
-        Column
-
-        Raises
-        ------
-        ValueError
-            If `keys` and `ascending` are sequences of different lengths.
-        """
-        ...
-
     def __eq__(self, other: AnyScalar) -> Self:  # type: ignore[override]
         """Compare for equality.
 
@@ -775,32 +737,6 @@ class DataFrame(Protocol):
         This only checks for 'NaN'.
         Does *not* include 'missing' or 'null' entries.
         In particular, does not check for `np.timedelta64('NaT')`.
-        """
-        ...
-
-    def unique_indices(self, *keys: str, skip_nulls: bool | Scalar = True) -> Column:
-        """Return indices corresponding to unique values across selected columns.
-
-        Parameters
-        ----------
-        *keys : str
-            Column names to consider when finding unique values.
-            If not specified, all columns are considered.
-
-        Returns
-        -------
-        Column
-            Indices corresponding to unique values.
-
-        Notes
-        -----
-        There are no ordering guarantees. In particular, if there are multiple
-        indices corresponding to the same unique value(s), there is no guarantee
-        about which one will appear in the result.
-        If the original column(s) contain multiple `'NaN'` values, then
-        only a single index corresponding to those values will be returned.
-        Likewise for null values (if ``skip_nulls=False``).
-        To get the unique values, you can do ``df.get_rows(df.unique_indices(keys))``.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -284,7 +284,7 @@ class DataFrame(Protocol):
         """Sort dataframe according to given columns.
 
         If you only need the indices which would sort the dataframe, use
-        :meth:`sorted_indices`.
+        `sorted_indices`.
 
         Parameters
         ----------

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -678,32 +678,6 @@ class DataFrame(Protocol):
         """
         ...
 
-    def any_rowwise(self, *, skip_nulls: bool | Scalar = True) -> Column:
-        """Reduction returns a Column.
-
-        Differs from ``DataFrame.any`` and that the reduction happens
-        for each row, rather than for each column.
-
-        Raises
-        ------
-        ValueError
-            If any of the DataFrame's columns is not boolean.
-        """
-        ...
-
-    def all_rowwise(self, *, skip_nulls: bool | Scalar = True) -> Column:
-        """Reduction returns a Column.
-
-        Differs from ``DataFrame.all`` and that the reduction happens
-        for each row, rather than for each column.
-
-        Raises
-        ------
-        ValueError
-            If any of the DataFrame's columns is not boolean.
-        """
-        ...
-
     def min(self, *, skip_nulls: bool | Scalar = True) -> Self:
         """Reduction returns a 1-row DataFrame."""
         ...

--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -132,14 +132,14 @@ class Namespace(Protocol):
     def any_horizontal(
         self,
         *columns: Column,
-        skip_nulls: bool | Scalar = True,
+        skip_nulls: bool = True,
     ) -> Column:
         ...
 
     def all_horizontal(
         self,
         *columns: Column,
-        skip_nulls: bool | Scalar = True,
+        skip_nulls: bool = True,
     ) -> Column:
         ...
 
@@ -154,7 +154,7 @@ class Namespace(Protocol):
     def unique_indices(
         self,
         *columns: Column,
-        skip_nulls: bool | Scalar = True,
+        skip_nulls: bool = True,
     ) -> Column:
         ...
 

--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -129,10 +129,18 @@ class Namespace(Protocol):
     def date(self, year: int, month: int, day: int) -> Scalar:
         ...
 
-    def any_horizontal(self, *columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+    def any_horizontal(
+        self,
+        *columns: Column,
+        skip_nulls: bool | Scalar = True,
+    ) -> Column:
         ...
 
-    def all_horizontal(self, *columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+    def all_horizontal(
+        self,
+        *columns: Column,
+        skip_nulls: bool | Scalar = True,
+    ) -> Column:
         ...
 
 

--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -152,7 +152,9 @@ class Namespace(Protocol):
         ...
 
     def unique_indices(
-        self, *columns: Column, skip_nulls: bool | Scalar = True,
+        self,
+        *columns: Column,
+        skip_nulls: bool | Scalar = True,
     ) -> Column:
         ...
 

--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -143,6 +143,19 @@ class Namespace(Protocol):
     ) -> Column:
         ...
 
+    def sorted_indices(
+        self,
+        *columns: Column,
+        ascending: Sequence[bool] | bool = True,
+        nulls_position: Literal["first", "last"] = "last",
+    ) -> Column:
+        ...
+
+    def unique_indices(
+        self, *columns: Column, skip_nulls: bool | Scalar = True,
+    ) -> Column:
+        ...
+
 
 DType = Union[
     Namespace.Bool,

--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -129,6 +129,12 @@ class Namespace(Protocol):
     def date(self, year: int, month: int, day: int) -> Scalar:
         ...
 
+    def any_horizontal(self, *columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+        ...
+
+    def all_horizontal(self, *columns: Column, skip_nulls: bool | Scalar = True) -> Column:
+        ...
+
 
 DType = Union[
     Namespace.Bool,

--- a/spec/API_specification/examples/06_horizontal_functions.py
+++ b/spec/API_specification/examples/06_horizontal_functions.py
@@ -1,0 +1,28 @@
+"""Example of how to use a horizontal function.
+
+Horizontal functions are functions that take multiple columns as input and return a
+single column as output.
+
+Examples include:
+- `any_horizontal`
+- `all_horizontal`
+
+These can be accessed by first using ``__dataframe_namespace__`` to get the
+namespace object, and then calling the function on the namespace object and passing
+an iterable of ``Column``s as input.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dataframe_api.typing import SupportsDataFrameAPI
+
+
+def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
+    df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta")
+    ns = df.__dataframe_namespace__()
+    df = df.filter(
+        ns.any_horizontal(*[df.col(col_name) > 0 for col_name in df.column_names]),
+    )
+    return df.dataframe


### PR DESCRIPTION
The current `any_rowwise` function isn't particularly useful for filtering:
```python
df: DataFrame
df.filter((df > 0).any_rowwise())
```
is undefined, because the parent dataframe of `(df > 0).any_rowwise()` is `df > 0`, not `df`

Solution: introduce `namespace.any_rowwise` and `namespace.all_rowwise`. Also, rename to `_horizontal` for familiarity to Polars users (I'm not aware of other names - in spark I think you're meant to do something like
```python
from functools import reduce
predicate = reduce(lambda a, b: a | b, [df[x] != 0 for x in cols])
```
)

Then, you can write
```python
    >>> df: DataFrame
    >>> ns = df.__dataframe_namespace__()
    >>> mask = ns.all_horizontal(
    ...     *[df.col(col_name) > 0 for col_name in df.column_names()]
    ... )
    >>> df = df.filter(mask)
```

Maybe, in a separate PR, we could add something like `ns.all()` for more easily doing some operation on all columns. But for now, this addresses the issue

This came up here https://github.com/skrub-data/skrub/pull/827/files#r1397599891

---

The same applies to `sorted_indices` and `unique_indices`.

As a design rule, I'd suggest not introducing `DataFrame` methods which return `Column`s - such methods should be top-level functions which accept `Column`s