### PR TITLE
Add DataFrame.iter_columns() and simplify

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -995,10 +995,11 @@ class DataFrame(Protocol):
             .. code-block:: python
 
                 df: DataFrame
-                df = df.persist()
                 features = []
+                result = df.std() > 0
+                result = result.persist()
                 for column_name in df.column_names:
-                    if df.col(column_name).std() > 0:
+                    if result.col(column_name).get_value(0):
                         features.append(column_name)
 
             instead of this:
@@ -1008,7 +1009,8 @@ class DataFrame(Protocol):
                 df: DataFrame
                 features = []
                 for column_name in df.column_names:
-                    # Do NOT do this!
+                    # Do NOT call `persist` on a `DataFrame` within a for-loop!
+                    # This may re-trigger the same computation multiple times
                     if df.persist().col(column_name).std() > 0:
                         features.append(column_name)
         """

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -275,7 +275,7 @@ class DataFrame(Protocol):
         """
         ...
 
-    def columns_iter(self) -> Iterator[Column]:
+    def iter_columns(self) -> Iterator[Column]:
         """Return iterator over columns."""
         ...
 
@@ -1001,7 +1001,7 @@ class DataFrame(Protocol):
                 df: DataFrame
                 result = df.std() > 0
                 result = result.persist()
-                features = [col.name for col in df.columns_iter() if col.get_value(0)]
+                features = [col.name for col in df.iter_columns() if col.get_value(0)]
 
             instead of this:
 
@@ -1012,7 +1012,7 @@ class DataFrame(Protocol):
                 features = [
                     # Do NOT do this! This will trigger execution of the entire
                     # pipeline for element in the for-loop!
-                    col.name for col in df.columns_iter() if col.get_value(0).persist()
+                    col.name for col in df.iter_columns() if col.get_value(0).persist()
                 ]
         """
         ...

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
 
     from typing_extensions import Self
 
@@ -273,6 +273,10 @@ class DataFrame(Protocol):
         dict[str, Any]
             Mapping from column name to data type.
         """
+        ...
+
+    def columns_iter(self) -> Iterator[Column]:
+        """Return iterator over columns."""
         ...
 
     def sort(
@@ -995,23 +999,20 @@ class DataFrame(Protocol):
             .. code-block:: python
 
                 df: DataFrame
-                features = []
                 result = df.std() > 0
                 result = result.persist()
-                for column_name in df.column_names:
-                    if result.col(column_name).get_value(0):
-                        features.append(column_name)
+                features = [col.name for col in df.columns_iter() if col.get_value(0)]
 
             instead of this:
 
             .. code-block:: python
 
                 df: DataFrame
-                features = []
-                for column_name in df.column_names:
-                    # Do NOT call `persist` on a `DataFrame` within a for-loop!
-                    # This may re-trigger the same computation multiple times
-                    if df.persist().col(column_name).std() > 0:
-                        features.append(column_name)
+                result = df.std() > 0
+                features = [
+                    # Do NOT do this! This will trigger execution of the entire
+                    # pipeline for element in the for-loop!
+                    col.name for col in df.columns_iter() if col.get_value(0).persist()
+                ]
         """
         ...

--- a/spec/API_specification/examples/01_standardise_columns.py
+++ b/spec/API_specification/examples/01_standardise_columns.py
@@ -9,11 +9,10 @@ if TYPE_CHECKING:
 def my_dataframe_agnostic_function(df_non_standard: SupportsDataFrameAPI) -> Any:
     df = df_non_standard.__dataframe_consortium_standard__(api_version="2023.09-beta")
 
-    for column_name in df.column_names:
-        if column_name == "species":
-            continue
-        new_column = df.col(column_name)
-        new_column = (new_column - new_column.mean()) / new_column.std()
-        df = df.assign(new_column.rename(f"{column_name}_scaled"))
+    new_columns = [
+        ((col - col.mean()) / col.std()).rename(f"{col.name}_scaled")
+        for col in df.columns_iter()
+    ]
+    df = df.assign(*new_columns)
 
     return df.dataframe

--- a/spec/API_specification/examples/01_standardise_columns.py
+++ b/spec/API_specification/examples/01_standardise_columns.py
@@ -11,7 +11,7 @@ def my_dataframe_agnostic_function(df_non_standard: SupportsDataFrameAPI) -> Any
 
     new_columns = [
         ((col - col.mean()) / col.std()).rename(f"{col.name}_scaled")
-        for col in df.columns_iter()
+        for col in df.iter_columns()
     ]
     df = df.assign(*new_columns)
 

--- a/spec/API_specification/examples/04_datatypes.py
+++ b/spec/API_specification/examples/04_datatypes.py
@@ -14,7 +14,7 @@ def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df.select(
         *[
             col.name
-            for col in df.columns_iter()
+            for col in df.iter_columns()
             if isinstance(col.dtype, namespace.Int64)
         ],
     )

--- a/spec/API_specification/examples/04_datatypes.py
+++ b/spec/API_specification/examples/04_datatypes.py
@@ -12,11 +12,7 @@ def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta").persist()
     pdx = df.__dataframe_namespace__()
     df = df.select(
-        *[
-            col.name
-            for col in df.iter_columns()
-            if isinstance(col.dtype, pdx.Int64)
-        ],
+        *[col.name for col in df.iter_columns() if isinstance(col.dtype, pdx.Int64)],
     )
     arr = df.to_array()
     arr = some_array_function(arr)

--- a/spec/API_specification/examples/04_datatypes.py
+++ b/spec/API_specification/examples/04_datatypes.py
@@ -13,9 +13,9 @@ def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     namespace = df.__dataframe_namespace__()
     df = df.select(
         *[
-            col_name
-            for col_name in df.column_names
-            if isinstance(df.col(col_name).dtype, namespace.Int64)
+            col.name
+            for col in df.columns_iter()
+            if isinstance(col.dtype, namespace.Int64)
         ],
     )
     arr = df.to_array(namespace.Int64())

--- a/spec/design_topics/execution_model.md
+++ b/spec/design_topics/execution_model.md
@@ -11,17 +11,13 @@ not be supported in some cases.
 For example, let's consider the following:
 ```python
 df: DataFrame
-features = []
-for column_name in df.column_names:
-    if df.col(column_name).std() > 0:
-        features.append(column_name)
-return features
+features = [col.name for col in df.columns_iter() if col.std() > 0]
 ```
-If `df` is a lazy dataframe, then the call `df.col(column_name).std() > 0` returns
+If `df` is a lazy dataframe, then the call `col.std() > 0` returns
 a (ducktyped) Python boolean scalar. No issues so far. Problem is,
-what happens when `if df.col(column_name).std() > 0` is called?
+what happens when `if col.std() > 0` is called?
 
-Under the hood, Python will call `(df.col(column_name).std() > 0).__bool__()` in
+Under the hood, Python will call `(col.std() > 0).__bool__()` in
 order to extract a Python boolean. This is a problem for "lazy" implementations,
 as the laziness needs breaking in order to evaluate the above.
 

--- a/spec/design_topics/execution_model.md
+++ b/spec/design_topics/execution_model.md
@@ -11,7 +11,7 @@ not be supported in some cases.
 For example, let's consider the following:
 ```python
 df: DataFrame
-features = [col.name for col in df.columns_iter() if col.std() > 0]
+features = [col.name for col in df.iter_columns() if col.std() > 0]
 ```
 If `df` is a lazy dataframe, then the call `col.std() > 0` returns
 a (ducktyped) Python boolean scalar. No issues so far. Problem is,


### PR DESCRIPTION
This simplifies a few examples and makes things more ergonomic

Can't just use `DataFrame.columns` as pandas / Polars already use that for column names unfortunately