### PR TITLE
Consistently use ns for namespace in docs/examples

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -293,10 +293,10 @@ def date(year: int, month: int, day: int) -> Scalar:
     Examples
     --------
     >>> df: DataFrame
-    >>> ns = df.__dataframe_namespace__()
+    >>> pdx = df.__dataframe_namespace__()
     >>> mask = (
-    ...     (df.get_column_by_name('date') >= ns.date(2020, 1, 1))
-    ...     & (df.get_column_by_name('date') < ns.date(2021, 1, 1))
+    ...     (df.get_column_by_name('date') >= pdx.date(2020, 1, 1))
+    ...     & (df.get_column_by_name('date') < pdx.date(2021, 1, 1))
     ... )
     >>> df.filter(mask)
     """

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -319,8 +319,8 @@ def any_horizontal(*columns: Column, skip_nulls: bool = True) -> Column:
     Examples
     --------
     >>> df: DataFrame
-    >>> ns = df.__dataframe_namespace__()
-    >>> mask = ns.any_horizontal(
+    >>> pdx = df.__dataframe_namespace__()
+    >>> mask = pdx.any_horizontal(
     ...     *[df.col(col_name) > 0 for col_name in df.column_names()]
     ... )
     >>> df = df.filter(mask)
@@ -345,8 +345,8 @@ def all_horizontal(*columns: Column, skip_nulls: bool = True) -> Column:
     Examples
     --------
     >>> df: DataFrame
-    >>> ns = df.__dataframe_namespace__()
-    >>> mask = ns.all_horizontal(
+    >>> pdx = df.__dataframe_namespace__()
+    >>> mask = pdx.all_horizontal(
     ...     *[df.col(col_name) > 0 for col_name in df.column_names()]
     ... )
     >>> df = df.filter(mask)

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -283,10 +283,10 @@ def date(year: int, month: int, day: int) -> Scalar:
     Examples
     --------
     >>> df: DataFrame
-    >>> namespace = df.__dataframe_namespace__()
+    >>> ns = df.__dataframe_namespace__()
     >>> mask = (
-    ...     (df.get_column_by_name('date') >= namespace.date(2020, 1, 1))
-    ...     & (df.get_column_by_name('date') < namespace.date(2021, 1, 1))
+    ...     (df.get_column_by_name('date') >= ns.date(2020, 1, 1))
+    ...     & (df.get_column_by_name('date') < ns.date(2021, 1, 1))
     ... )
     >>> df.filter(mask)
     """

--- a/spec/API_specification/dataframe_api/groupby_object.py
+++ b/spec/API_specification/dataframe_api/groupby_object.py
@@ -72,13 +72,13 @@ class GroupBy(Protocol):
         Examples
         --------
         >>> df: DataFrame
-        >>> namespace = df.__dataframe_namespace__()
+        >>> ns = df.__dataframe_namespace__()
         >>> df.group_by('year').aggregate(
-        ...     namespace.Aggregation.sum('l_quantity').rename('sum_qty'),
-        ...     namespace.Aggregation.mean('l_quantity').rename('avg_qty'),
-        ...     namespace.Aggregation.mean('l_extended_price').rename('avg_price'),
-        ...     namespace.Aggregation.mean('l_discount').rename('avg_disc'),
-        ...     namespace.Aggregation.size().rename('count_order'),
+        ...     ns.Aggregation.sum('l_quantity').rename('sum_qty'),
+        ...     ns.Aggregation.mean('l_quantity').rename('avg_qty'),
+        ...     ns.Aggregation.mean('l_extended_price').rename('avg_price'),
+        ...     ns.Aggregation.mean('l_discount').rename('avg_disc'),
+        ...     ns.Aggregation.size().rename('count_order'),
         ... )
         """
         ...

--- a/spec/API_specification/dataframe_api/groupby_object.py
+++ b/spec/API_specification/dataframe_api/groupby_object.py
@@ -72,13 +72,13 @@ class GroupBy(Protocol):
         Examples
         --------
         >>> df: DataFrame
-        >>> ns = df.__dataframe_namespace__()
+        >>> pdx = df.__dataframe_namespace__()
         >>> df.group_by('year').aggregate(
-        ...     ns.Aggregation.sum('l_quantity').rename('sum_qty'),
-        ...     ns.Aggregation.mean('l_quantity').rename('avg_qty'),
-        ...     ns.Aggregation.mean('l_extended_price').rename('avg_price'),
-        ...     ns.Aggregation.mean('l_discount').rename('avg_disc'),
-        ...     ns.Aggregation.size().rename('count_order'),
+        ...     pdx.Aggregation.sum('l_quantity').rename('sum_qty'),
+        ...     pdx.Aggregation.mean('l_quantity').rename('avg_qty'),
+        ...     pdx.Aggregation.mean('l_extended_price').rename('avg_price'),
+        ...     pdx.Aggregation.mean('l_discount').rename('avg_disc'),
+        ...     pdx.Aggregation.size().rename('count_order'),
         ... )
         """
         ...

--- a/spec/API_specification/examples/02_plotting.py
+++ b/spec/API_specification/examples/02_plotting.py
@@ -19,9 +19,9 @@ def group_by_and_plot(
     y = y_any.__column_consortium_standard__(api_version="2023-10.beta")
     color = color_any.__column_consortium_standard__(api_version="2023-10.beta")
 
-    namespace = x.__column_namespace__()
+    ns = x.__column_namespace__()
 
-    df = namespace.dataframe_from_columns(
+    df = ns.dataframe_from_columns(
         x.rename("x"),
         y.rename("y"),
         color.rename("color"),

--- a/spec/API_specification/examples/02_plotting.py
+++ b/spec/API_specification/examples/02_plotting.py
@@ -19,9 +19,9 @@ def group_by_and_plot(
     y = y_any.__column_consortium_standard__(api_version="2023-10.beta")
     color = color_any.__column_consortium_standard__(api_version="2023-10.beta")
 
-    ns = x.__column_namespace__()
+    pdx = x.__column_namespace__()
 
-    df = ns.dataframe_from_columns(
+    df = pdx.dataframe_from_columns(
         x.rename("x"),
         y.rename("y"),
         color.rename("color"),

--- a/spec/API_specification/examples/03_working_with_nulls.py
+++ b/spec/API_specification/examples/03_working_with_nulls.py
@@ -9,6 +9,6 @@ if TYPE_CHECKING:
 
 def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta")
-    ns = df.__dataframe_namespace__()
-    df = df.fill_nan(ns.null)
+    pdx = df.__dataframe_namespace__()
+    df = df.fill_nan(pdx.null)
     return df.dataframe

--- a/spec/API_specification/examples/03_working_with_nulls.py
+++ b/spec/API_specification/examples/03_working_with_nulls.py
@@ -9,6 +9,6 @@ if TYPE_CHECKING:
 
 def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta")
-    namespace = df.__dataframe_namespace__()
-    df = df.fill_nan(namespace.null)
+    ns = df.__dataframe_namespace__()
+    df = df.fill_nan(ns.null)
     return df.dataframe

--- a/spec/API_specification/examples/04_datatypes.py
+++ b/spec/API_specification/examples/04_datatypes.py
@@ -10,15 +10,15 @@ some_array_function: Callable[[Any], Any]
 
 def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta").persist()
-    ns = df.__dataframe_namespace__()
+    pdx = df.__dataframe_namespace__()
     df = df.select(
         *[
             col_name
             for col_name in df.column_names
-            if isinstance(df.col(col_name).dtype, ns.Int64)
+            if isinstance(df.col(col_name).dtype, pdx.Int64)
         ],
     )
-    arr = df.to_array(ns.Int64())
+    arr = df.to_array(pdx.Int64())
     arr = some_array_function(arr)
-    df = ns.dataframe_from_2d_array(arr, names=["a", "b"])
+    df = pdx.dataframe_from_2d_array(arr, names=["a", "b"])
     return df.dataframe

--- a/spec/API_specification/examples/04_datatypes.py
+++ b/spec/API_specification/examples/04_datatypes.py
@@ -10,18 +10,18 @@ some_array_function: Callable[[Any], Any]
 
 def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta").persist()
-    namespace = df.__dataframe_namespace__()
+    ns = df.__dataframe_namespace__()
     df = df.select(
         *[
             col_name
             for col_name in df.column_names
-            if isinstance(df.col(col_name).dtype, namespace.Int64)
+            if isinstance(df.col(col_name).dtype, ns.Int64)
         ],
     )
-    arr = df.to_array(namespace.Int64())
+    arr = df.to_array(ns.Int64())
     arr = some_array_function(arr)
-    df = namespace.dataframe_from_2d_array(
+    df = ns.dataframe_from_2d_array(
         arr,
-        schema={"a": df.col("a").dtype, "b": namespace.Float64()},
+        schema={"a": df.col("a").dtype, "b": ns.Float64()},
     )
     return df.dataframe

--- a/spec/API_specification/examples/06_horizontal_functions.py
+++ b/spec/API_specification/examples/06_horizontal_functions.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 
 def main(df_raw: SupportsDataFrameAPI) -> SupportsDataFrameAPI:
     df = df_raw.__dataframe_consortium_standard__(api_version="2023-11.beta")
-    ns = df.__dataframe_namespace__()
+    pdx = df.__dataframe_namespace__()
     df = df.filter(
-        ns.any_horizontal(*[df.col(col_name) > 0 for col_name in df.column_names]),
+        pdx.any_horizontal(*[df.col(col_name) > 0 for col_name in df.column_names]),
     )
     return df.dataframe

--- a/spec/API_specification/examples/tpch/q1.py
+++ b/spec/API_specification/examples/tpch/q1.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
 
 def query(lineitem_raw: SupportsDataFrameAPI) -> Any:
     lineitem = lineitem_raw.__dataframe_consortium_standard__(api_version="2023.10-beta")
-    ns = lineitem.__dataframe_namespace__()
+    pdx = lineitem.__dataframe_namespace__()
 
-    mask = lineitem.col("l_shipdate") <= ns.date(1998, 9, 2)
+    mask = lineitem.col("l_shipdate") <= pdx.date(1998, 9, 2)
     lineitem = lineitem.assign(
         (lineitem.col("l_extended_price") * (1 - lineitem.col("l_discount"))).rename(
             "l_disc_price",
@@ -25,13 +25,13 @@ def query(lineitem_raw: SupportsDataFrameAPI) -> Any:
         lineitem.filter(mask)
         .group_by("l_returnflag", "l_linestatus")
         .aggregate(
-            ns.Aggregation.sum("l_quantity").rename("sum_qty"),
-            ns.Aggregation.sum("l_extendedprice").rename("sum_base_price"),
-            ns.Aggregation.sum("l_disc_price").rename("sum_disc_price"),
-            ns.Aggregation.sum("change").rename("sum_charge"),
-            ns.Aggregation.mean("l_quantity").rename("avg_qty"),
-            ns.Aggregation.mean("l_discount").rename("avg_disc"),
-            ns.Aggregation.size().rename("count_order"),
+            pdx.Aggregation.sum("l_quantity").rename("sum_qty"),
+            pdx.Aggregation.sum("l_extendedprice").rename("sum_base_price"),
+            pdx.Aggregation.sum("l_disc_price").rename("sum_disc_price"),
+            pdx.Aggregation.sum("change").rename("sum_charge"),
+            pdx.Aggregation.mean("l_quantity").rename("avg_qty"),
+            pdx.Aggregation.mean("l_discount").rename("avg_disc"),
+            pdx.Aggregation.size().rename("count_order"),
         )
         .sort("l_returnflag", "l_linestatus")
     )

--- a/spec/API_specification/examples/tpch/q1.py
+++ b/spec/API_specification/examples/tpch/q1.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
 
 def query(lineitem_raw: SupportsDataFrameAPI) -> Any:
     lineitem = lineitem_raw.__dataframe_consortium_standard__(api_version="2023.10-beta")
-    namespace = lineitem.__dataframe_namespace__()
+    ns = lineitem.__dataframe_namespace__()
 
-    mask = lineitem.col("l_shipdate") <= namespace.date(1998, 9, 2)
+    mask = lineitem.col("l_shipdate") <= ns.date(1998, 9, 2)
     lineitem = lineitem.assign(
         (lineitem.col("l_extended_price") * (1 - lineitem.col("l_discount"))).rename(
             "l_disc_price",
@@ -25,13 +25,13 @@ def query(lineitem_raw: SupportsDataFrameAPI) -> Any:
         lineitem.filter(mask)
         .group_by("l_returnflag", "l_linestatus")
         .aggregate(
-            namespace.Aggregation.sum("l_quantity").rename("sum_qty"),
-            namespace.Aggregation.sum("l_extendedprice").rename("sum_base_price"),
-            namespace.Aggregation.sum("l_disc_price").rename("sum_disc_price"),
-            namespace.Aggregation.sum("change").rename("sum_charge"),
-            namespace.Aggregation.mean("l_quantity").rename("avg_qty"),
-            namespace.Aggregation.mean("l_discount").rename("avg_disc"),
-            namespace.Aggregation.size().rename("count_order"),
+            ns.Aggregation.sum("l_quantity").rename("sum_qty"),
+            ns.Aggregation.sum("l_extendedprice").rename("sum_base_price"),
+            ns.Aggregation.sum("l_disc_price").rename("sum_disc_price"),
+            ns.Aggregation.sum("change").rename("sum_charge"),
+            ns.Aggregation.mean("l_quantity").rename("avg_qty"),
+            ns.Aggregation.mean("l_discount").rename("avg_disc"),
+            ns.Aggregation.size().rename("count_order"),
         )
         .sort("l_returnflag", "l_linestatus")
     )

--- a/spec/API_specification/examples/tpch/q5.py
+++ b/spec/API_specification/examples/tpch/q5.py
@@ -39,7 +39,7 @@ def query(
     nation = nation_raw.__dataframe_consortium_standard__(api_version="2023-10.beta")
     region = region_raw.__dataframe_consortium_standard__(api_version="2023-10.beta")
 
-    ns = customer.__dataframe_namespace__()
+    pdx = customer.__dataframe_namespace__()
 
     result = (
         region.join(nation, how="inner", left_on="r_regionkey", right_on="n_regionkey")
@@ -56,8 +56,8 @@ def query(
     mask = (
         (result.col("c_nationkey") == result.col("s_nationkey"))
         & (result.col("r_name") == "ASIA")
-        & (result.col("o_orderdate") >= ns.date(1994, 1, 1))
-        & (result.col("o_orderdate") < ns.date(1995, 1, 1))
+        & (result.col("o_orderdate") >= pdx.date(1994, 1, 1))
+        & (result.col("o_orderdate") < pdx.date(1995, 1, 1))
     )
     result = result.filter(mask)
 
@@ -65,6 +65,6 @@ def query(
         "revenue",
     )
     result = result.assign(new_column)
-    result = result.group_by("n_name").aggregate(ns.Aggregation.sum("revenue"))
+    result = result.group_by("n_name").aggregate(pdx.Aggregation.sum("revenue"))
 
     return result.dataframe

--- a/spec/API_specification/examples/tpch/q5.py
+++ b/spec/API_specification/examples/tpch/q5.py
@@ -39,7 +39,7 @@ def query(
     nation = nation_raw.__dataframe_consortium_standard__(api_version="2023-10.beta")
     region = region_raw.__dataframe_consortium_standard__(api_version="2023-10.beta")
 
-    namespace = customer.__dataframe_namespace__()
+    ns = customer.__dataframe_namespace__()
 
     result = (
         region.join(nation, how="inner", left_on="r_regionkey", right_on="n_regionkey")
@@ -56,8 +56,8 @@ def query(
     mask = (
         (result.col("c_nationkey") == result.col("s_nationkey"))
         & (result.col("r_name") == "ASIA")
-        & (result.col("o_orderdate") >= namespace.date(1994, 1, 1))
-        & (result.col("o_orderdate") < namespace.date(1995, 1, 1))
+        & (result.col("o_orderdate") >= ns.date(1994, 1, 1))
+        & (result.col("o_orderdate") < ns.date(1995, 1, 1))
     )
     result = result.filter(mask)
 
@@ -65,6 +65,6 @@ def query(
         "revenue",
     )
     result = result.assign(new_column)
-    result = result.group_by("n_name").aggregate(namespace.Aggregation.sum("revenue"))
+    result = result.group_by("n_name").aggregate(ns.Aggregation.sum("revenue"))
 
     return result.dataframe


### PR DESCRIPTION
`namespace = dataframe.__dataframe_namespace__()` is quite verbose, how about just using a 2-letter acronym in the examples? most people alias namespace to 2-letter acronyms anyway