### PR TITLE
fixup typing of Duration and Datetime dtypes

### DIFF
--- a/spec/API_specification/dataframe_api/typing.py
+++ b/spec/API_specification/dataframe_api/typing.py
@@ -69,6 +69,9 @@ class Namespace(Protocol):
     null: NullType
 
     class Datetime:
+        time_unit: Literal['ms', 'us']
+        time_zone: str | None
+
         def __init__(  # noqa: ANN204
             self,
             time_unit: Literal["ms", "us"],
@@ -77,6 +80,8 @@ class Namespace(Protocol):
             ...
 
     class Duration:
+        time_unit: Literal['ms', 'us']
+
         def __init__(  # noqa: ANN204
             self,
             time_unit: Literal["ms", "us"],


### PR DESCRIPTION
add the `time_unit` and `time_zone` attributes