### PR TITLE
add Scalar.scalar

### DIFF
--- a/spec/API_specification/dataframe_api/scalar_object.py
+++ b/spec/API_specification/dataframe_api/scalar_object.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/spec/API_specification/dataframe_api/scalar_object.py
+++ b/spec/API_specification/dataframe_api/scalar_object.py
@@ -40,6 +40,11 @@ class Scalar(Protocol):
         """
         ...
 
+    @property
+    def scalar(self) -> Any:
+        """Return underlying (not-necessarily-Standard-compliant) scalar object."""
+        ...
+
     def __lt__(self, other: AnyScalar) -> Scalar:
         ...
 


### PR DESCRIPTION
There are already:
- `DataFrame.dataframe`
- `Column.column`

so I think there should also be `Scalar.scalar`

This also solves the problem of how to get the scalar object our of a Scalar if it's not one you can call `__bool__` on (say, to get a Python scalar out of a Duration column)