### PR TITLE
rename get_rows to take

### DIFF
--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -413,6 +413,6 @@ def unique_indices(*columns: Column, skip_nulls: bool = True) -> Column:
     If the original column(s) contain multiple `'NaN'` values, then
     only a single index corresponding to those values will be returned.
     Likewise for null values (if ``skip_nulls=False``).
-    To get the unique values, you can do ``df.gather(df.unique_indices(keys))``.
+    To get the unique values, you can do ``df.take(df.unique_indices(keys))``.
     """
     ...

--- a/spec/API_specification/dataframe_api/__init__.py
+++ b/spec/API_specification/dataframe_api/__init__.py
@@ -413,6 +413,6 @@ def unique_indices(*columns: Column, skip_nulls: bool = True) -> Column:
     If the original column(s) contain multiple `'NaN'` values, then
     only a single index corresponding to those values will be returned.
     Likewise for null values (if ``skip_nulls=False``).
-    To get the unique values, you can do ``df.get_rows(df.unique_indices(keys))``.
+    To get the unique values, you can do ``df.gather(df.unique_indices(keys))``.
     """
     ...

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -110,7 +110,7 @@ class Column(Protocol):
         """Return data type of column."""
         ...
 
-    def gather(self, indices: Self) -> Self:
+    def take(self, indices: Self) -> Self:
         """Select a subset of rows, similar to `ndarray.take`.
 
         Parameters
@@ -856,7 +856,7 @@ class Column(Protocol):
         If the original Column contains multiple `'NaN'` values, then
         only a single index corresponding to those values will be returned.
         Likewise for null values (if ``skip_nulls=False``).
-        To get the unique values, you can do ``col.gather(col.unique_indices())``.
+        To get the unique values, you can do ``col.take(col.unique_indices())``.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/column_object.py
+++ b/spec/API_specification/dataframe_api/column_object.py
@@ -110,7 +110,7 @@ class Column(Protocol):
         """Return data type of column."""
         ...
 
-    def get_rows(self, indices: Self) -> Self:
+    def gather(self, indices: Self) -> Self:
         """Select a subset of rows, similar to `ndarray.take`.
 
         Parameters
@@ -856,7 +856,7 @@ class Column(Protocol):
         If the original Column contains multiple `'NaN'` values, then
         only a single index corresponding to those values will be returned.
         Likewise for null values (if ``skip_nulls=False``).
-        To get the unique values, you can do ``col.get_rows(col.unique_indices())``.
+        To get the unique values, you can do ``col.gather(col.unique_indices())``.
         """
         ...
 

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -132,7 +132,7 @@ class DataFrame(Protocol):
         """
         ...
 
-    def gather(self, indices: Column) -> Self:
+    def take(self, indices: Column) -> Self:
         """Select a subset of rows, similar to `ndarray.take`.
 
         Parameters

--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -132,7 +132,7 @@ class DataFrame(Protocol):
         """
         ...
 
-    def get_rows(self, indices: Column) -> Self:
+    def gather(self, indices: Column) -> Self:
         """Select a subset of rows, similar to `ndarray.take`.
 
         Parameters


### PR DESCRIPTION
In pandas, there's `.iloc`, but the consortium doesn't want that

Polars has `.gather`

pytorch also uses `gather` for this kind of operation:
```python
>>> t = torch.tensor([1, 2, 3, 4])
>>> torch.gather(t, 0, torch.tensor([3, 2]))
tensor([4, 3])
```

tensorflow has `gather`, which does the same kind of thing https://www.tensorflow.org/api_docs/python/tf/gather

I've not seen `get_rows` anywhere, it's definitely not a common name. Personally I'd rather go with common existing names than create new ones

I promise I'll stop bikeshedding after February (when we aim to make the first non-beta release), trying to get it all out before then