### PR TITLE
rename: drop_columns -> drop, rename_columns -> rename

### DIFF
--- a/spec/API_specification/dataframe_api/dataframe_object.py
+++ b/spec/API_specification/dataframe_api/dataframe_object.py
@@ -221,7 +221,7 @@ class DataFrame(Protocol):
         """
         ...
 
-    def drop_columns(self, *labels: str) -> Self:
+    def drop(self, *labels: str) -> Self:
         """Drop the specified column(s).
 
         Parameters
@@ -240,7 +240,7 @@ class DataFrame(Protocol):
         """
         ...
 
-    def rename_columns(self, mapping: Mapping[str, str]) -> Self:
+    def rename(self, mapping: Mapping[str, str]) -> Self:
         """Rename columns.
 
         Parameters
@@ -863,7 +863,7 @@ class DataFrame(Protocol):
 
         Other than the joining column name(s), no column name is allowed to appear in
         both `self` and `other`. Rename columns before calling `join` if necessary
-        using :meth:`rename_columns`.
+        using :meth:`rename`.
 
         Parameters
         ----------


### PR DESCRIPTION
In general, most methods which work on columns don't have a `_columns` suffix:
- we have `DataFrame.assign`, not `DataFrame.assign_columns`
- `DataFrame.select`, not `DataFrame.select_columns`

I suggest just having `DataFrame.drop` and `DataFrame.rename` then (it's not like they're ambiguous - we don't have row labels in the standard, so it's not like they can refer to row labels...)