### PR TITLE
Add methods for the Arrow PyCapsule Protocol to DataFrame/Column interchange protocol objects

### DIFF
--- a/protocol/dataframe_protocol.py
+++ b/protocol/dataframe_protocol.py
@@ -350,6 +350,41 @@ class Column(ABC):
         """
         pass
 
+    def __arrow_c_schema__(self) -> object:
+        """
+        Export the data type of the Column to a Arrow C schema PyCapsule.
+
+        Returns
+        -------
+        PyCapsule
+        """
+        pass
+
+    def __arrow_c_array__(
+        self, requested_schema: Optional[object] = None
+    ) -> Tuple[object, object]:
+        """
+        Export the Column as an Arrow C array and schema PyCapsule.
+
+        If the Column consists of multiple chunks, this method should raise
+        an error.
+
+        Parameters
+        ----------
+        requested_schema : PyCapsule, default None
+            The schema to which the dataframe should be casted, passed as a
+            PyCapsule containing a C ArrowSchema representation of the
+            requested schema.
+            If None, the array will be returned as-is, with a type matching the
+            one returned by ``__arrow_c_schema__()``.
+
+        Returns
+        -------
+        Tuple[PyCapsule, PyCapsule]
+            A pair of PyCapsules containing a C ArrowSchema and ArrowArray,
+            respectively.
+        """
+        pass
 
 #    def get_children(self) -> Iterable[Column]:
 #        """
@@ -488,5 +523,34 @@ class DataFrame(ABC):
 
         Note that the producer must ensure that all columns are chunked the
         same way.
+        """
+        pass
+
+    def __arrow_c_schema__(self) -> object:
+        """
+        Export the schema of the DataFrae to a Arrow C schema PyCapsule.
+
+        Returns
+        -------
+        PyCapsule
+        """
+        pass
+
+    def __arrow_c_stream__(self, requested_schema: Optional[object] = None) -> object:
+        """
+        Export the DataFrame as an Arrow C stream PyCapsule.
+
+        Parameters
+        ----------
+        requested_schema : PyCapsule, default None
+            The schema to which the dataframe should be casted, passed as a
+            PyCapsule containing a C ArrowSchema representation of the
+            requested schema.
+            If None, the array will be returned as-is, with a type matching the
+            one returned by ``__arrow_c_schema__()``.
+
+        Returns
+        -------
+        PyCapsule
         """
         pass


### PR DESCRIPTION
Addresses https://github.com/data-apis/dataframe-api/issues/279

Currently, I added schema and array support to `Column`, and schema and stream support to `DataFrame`. I _think_ that's the typical way those objects are used (chunked dataframe, gets chunks+columns, and then single-chunk column), but for completeness (and because the spec doesn't distinguish between single vs multi-chunk objects) we can probably add both the array and stream method to both the DataFrame and Column object. 

I also added the schema method to both DataFrame and Column, although those are strictly speaking not "schema" objects. But we don't have a dedicated schema object in the interchange spec (DataFrame has no attribute, and the Column.dtype attribute is a plain tuple)