### PR TITLE
Exclude `__parameters__`, `__abstractmethods__` from API

### DIFF
--- a/spec/conf.py
+++ b/spec/conf.py
@@ -51,7 +51,7 @@ autodoc_default_options = {
     'members':          True,
     'special-members':  True,
     'undoc-members':    True,
-    'exclude-members': '__annotations__, __dict__,__weakref__,__module__,__hash__',
+    'exclude-members': '__annotations__, __dict__,__weakref__,__module__,__hash__,__parameters__,__abstractmethods__',
 }
 add_module_names = False
 napoleon_numpy_docstring = True


### PR DESCRIPTION
Closes #314